### PR TITLE
Create partitioned table

### DIFF
--- a/forwarder/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/forwarder/Forwarder.scala
+++ b/forwarder/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/forwarder/Forwarder.scala
@@ -22,9 +22,6 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO
 import org.apache.beam.sdk.transforms.windowing.{AfterProcessingTime, Repeatedly}
 import org.apache.beam.sdk.values.WindowingStrategy.AccumulationMode
 import com.snowplowanalytics.snowplow.storage.bigquery.forwarder.CommandLine.ForwarderEnvironment
-import com.spotify.scio.bigquery.TableRow
-import org.apache.beam.sdk.transforms.SerializableFunction
-import org.apache.beam.sdk.util.Transport
 
 object Forwarder {
 

--- a/forwarder/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/forwarder/SerializeJsonRow.scala
+++ b/forwarder/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/forwarder/SerializeJsonRow.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.storage.bigquery.forwarder
+
+import com.spotify.scio.bigquery.TableRow
+import org.apache.beam.sdk.transforms.SerializableFunction
+import org.apache.beam.sdk.util.Transport
+
+/** Extract TableRow from Json string*/
+object SerializeJsonRow extends SerializableFunction[String, TableRow] {
+  def apply(input: String): TableRow =
+    Transport.getJsonFactory.fromString(input, classOf[TableRow])
+}
+

--- a/mutator/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/mutator/TableReference.scala
+++ b/mutator/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/mutator/TableReference.scala
@@ -62,7 +62,8 @@ object TableReference {
     def create(client: BigQuery, datasetId: String, tableId: String): IO[Table] = IO {
       val id = TableId.of(datasetId, tableId)
       val schema = BqSchema.of(Atomic.table.map(Adapter.adaptField).asJava)
-      val definition = StandardTableDefinition.newBuilder().setSchema(schema).build()
+      val partition = TimePartitioning.newBuilder(TimePartitioning.Type.DAY).setField("derived_tstamp").build()
+      val definition = StandardTableDefinition.newBuilder().setSchema(schema).setTimePartitioning(partition).build()
       val tableInfo = TableInfo.newBuilder(id, definition).build()
       client.create(tableInfo)
     }


### PR DESCRIPTION
- Create partitioned table with on derived_tstamp field
- BigQueryIO.write() should be used with withFormatFunction, json representation of TableRow is parsed to TableRow