### PR TITLE
Common: Add sbt-assembly (fixes #135)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("org.scalameta"             % "sbt-scalafmt"           % "2.3.2")
 addSbtPlugin("org.scalastyle"            %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"          % "sbt-native-packager"    % "1.3.6")
+addSbtPlugin("com.eed3si9n"              % "sbt-assembly"           % "0.15.0")
 addSbtPlugin("com.eed3si9n"              % "sbt-buildinfo"          % "0.9.0")
 addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"           % "0.9.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"           % "0.1.13")


### PR DESCRIPTION
Fix #135 by adding `sbt-assembly`. I needed this to be able to deploy a Snowplow pipeline on NixOS without resorting to Docker.

`activation-1.1.jar` had to be removed in order for this to work - this should probably be solved differently in the future, since it likely points to deeper issues (according to the `sbt-assembly` docs).

Disclaimer: I don't know Scala :)