### PR TITLE
Remove intermediate queue in StreamLoader

### DIFF
--- a/streamloader/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/streamloader/StreamLoader.scala
+++ b/streamloader/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/streamloader/StreamLoader.scala
@@ -18,7 +18,6 @@ import cats.implicits._
 import cats.effect.{Clock, Concurrent, ContextShift, IO, Timer}
 
 import fs2.Pipe
-import fs2.concurrent.Queue
 
 import com.snowplowanalytics.iglu.client.Resolver
 
@@ -50,23 +49,24 @@ object StreamLoader {
   private val MaxConcurrency = Runtime.getRuntime.availableProcessors * 16
   private val GroupByN       = 10
   private val TimeWindow     = 30.seconds
-  private val QueueSize      = 1024
 
   def run(e: Environment)(implicit CS: ContextShift[IO], C: Concurrent[IO], T: Timer[IO]): IO[Unit] =
     Resources.acquire(e).use { resources =>
       val eventStream = resources.source.evalMap(parse(resources.igluClient.resolver))
 
-      for {
-        queue <- Queue.bounded[IO, Set[ShreddedType]](QueueSize)
-        sinkBadGood = eventStream
-          .observeEither[StreamBadRow[IO], StreamLoaderRow[IO]](
-            resources.badRowsSink,
-            goodSink(resources, queue)
-          )
-          .void
-        sinkTypes = queue.dequeue.through(aggregateTypes(GroupByN, TimeWindow)).through(resources.typesSink)
-        _ <- sinkBadGood.merge(sinkTypes).compile.drain
-      } yield ()
+      val goodPipe: Pipe[IO, StreamLoaderRow[IO], Unit] =
+        _.observe(goodSink(resources))
+          .map(_.row.inventory)
+          .through(aggregateTypes(GroupByN, TimeWindow))
+          .through(resources.typesSink)
+
+      eventStream
+        .observeEither[StreamBadRow[IO], StreamLoaderRow[IO]](
+          resources.badRowsSink,
+          goodPipe
+        )
+        .compile
+        .drain
     }
 
   /** Parse a PubSub message into a `LoaderRow` (or `BadRow`) and attach `ack` action to be used after sink. */
@@ -79,16 +79,13 @@ object StreamLoader {
   /**
     * Enqueue observed types to a pre-aggregation queue and then route rows through a BigQuery sink.
     *
-    * @param types A queue in which observed types will be put.
     * @return      A sink that combines enqueueing observed types with sinking rows to BigQuery and failed inserts to Pub/Sub.
     */
   def goodSink(
-    r: Resources[IO],
-    types: Queue[IO, Set[ShreddedType]]
+    r: Resources[IO]
   )(implicit CS: ContextShift[IO]): Pipe[IO, StreamLoaderRow[IO], Unit] =
     _.parEvalMapUnordered(MaxConcurrency) { slrow =>
-      types.enqueue1(slrow.row.inventory) *>
-        r.blocker.blockOn(Bigquery.insert(r, slrow.row) *> slrow.ack)
+      r.blocker.blockOn(Bigquery.insert(r, slrow.row) *> slrow.ack)
     }
 
   /**


### PR DESCRIPTION
I'm offering this as suggestion for discussion: I have removed the queue from the streamloader, and instead I stream directly through the pipes.

For me, this implementation is cleaner because it doesn't require mutable state (the queue), it is more direct, and it avoids questions about what happens when queue size exceeds 1024.

I have done nothing to prove this performs any better, and it is completely untested.