### PR TITLE
Fix graceful shutdown version 2

### DIFF
--- a/config/config.reference.hocon
+++ b/config/config.reference.hocon
@@ -66,7 +66,6 @@
         "bqWriteRequestTimeout": "1 second"
         # For the HTTP request size limit, see https://cloud.google.com/bigquery/quotas#streaminginserts
         "bqWriteRequestSizeLimit": 10000000
-        "bqWriteRequestOverflowQueueMaxSize": 500
         "sinkConcurrency": 64
       }
 

--- a/modules/common/src/main/resources/application.conf
+++ b/modules/common/src/main/resources/application.conf
@@ -39,7 +39,6 @@
         "bqWriteRequestThreshold": 500
         "bqWriteRequestTimeout": "1 second"
         "bqWriteRequestSizeLimit": 10000000
-        "bqWriteRequestOverflowQueueMaxSize": 500
         "sinkConcurrency": 1024
       }
 

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/config/model.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/config/model.scala
@@ -128,7 +128,6 @@ object model {
       bqWriteRequestThreshold: Int,
       bqWriteRequestTimeout: FiniteDuration,
       bqWriteRequestSizeLimit: Int,
-      bqWriteRequestOverflowQueueMaxSize: Int,
       sinkConcurrency: Int
     )
 

--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/SpecHelpers.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/SpecHelpers.scala
@@ -537,13 +537,11 @@ object SpecHelpers {
     private val bqWriteRequestThreshold: Int            = 500
     private val bqWriteRequestTimeout: FiniteDuration   = FiniteDuration(1L, SECONDS)
     private val bqWriteRequestSizeLimit: Int            = 10000000
-    private val bqWriteRequestOverflowQueueMaxSize: Int = 500
     private val goodSinkConcurrency: Int                = 1024
     private val sinkSettingsGood = SinkSettings.Good(
       bqWriteRequestThreshold,
       bqWriteRequestTimeout,
       bqWriteRequestSizeLimit,
-      bqWriteRequestOverflowQueueMaxSize,
       goodSinkConcurrency
     )
     private val badProducerBatchSize: Long                 = 8L


### PR DESCRIPTION
This is an alternative solution, instead of #259.

I much much prefer this solution.  Graceful shutdown was broken because the buffer overflow queue was not shutdown properly.  PR #259 tried to fix it by explicitly shutting down the queue, by I consider that solution to be fragile and adding technical debt.

Whereas this solution gets around the problem by removing the buffer overflow queue entirely.