### PR TITLE
StreamLoader Monitoring: Add Latency to Stdout

### DIFF
--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/metrics/StdoutReporter.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/metrics/StdoutReporter.scala
@@ -32,7 +32,8 @@ object StdoutReporter {
             val failedInsert    = s"FailedInsert = ${lms.failedInsertCount}"
             val badEvent        = s"BadEvent = ${lms.badCount}"
             val types           = s"Types = ${lms.typesCount}"
-            Logger[F].info(s"$logPeriod, $total, $good, $failedInsert, $badEvent, $types")
+            val latency         = s"Latency = ${lms.latency.getOrElse(0)}"
+            Logger[F].info(s"$logPeriod, $total, $good, $failedInsert, $badEvent, $types, $latency")
           case rms: Metrics.MetricsSnapshot.RepeaterMetricsSnapshot =>
             val logPeriod    = s"${Metrics.normalizeMetric(config.prefix, "Statistics")} = ${config.period}"
             val uninsertable = s"UninsertableEvents = ${rms.uninsertableCount}"


### PR DESCRIPTION
The Stream loader metrics were introduced in #165. The `Latency` metric, however, was only added to `Statsd` and not `stdout`. 
This PR adds the missing `latency` to `stdout`. This is particularly important for GCE hosts running on Container optimised OSs and local testing. COS images do not support the GCP ops agent which is a prerequisite for the Statsd plugin.