### PR TITLE
Introduce cache for fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+.idea/
+.bsp/
+

--- a/modules/benchmark/src/test/scala/com.snowplowanalytics.snowplow.storage.bigquery.benchmark/FromEventBenchmark.scala
+++ b/modules/benchmark/src/test/scala/com.snowplowanalytics.snowplow.storage.bigquery.benchmark/FromEventBenchmark.scala
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.snowplow.storage.bigquery.benchmark
 
 import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow
-import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.implicits.idClock
+import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.clocks.idClock
 
 import cats.Id
 import org.openjdk.jmh.annotations._
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit
 class FromEventBenchmark {
   @Benchmark
   def fromEvent(state: States.ExampleEventState): Unit = {
-    LoaderRow.fromEvent[Id](state.resolver, state.processor)(state.baseEvent)
+    LoaderRow.fromEvent[Id](state.resolver, state.processor, state.fieldCache)(state.baseEvent)
     ()
   }
 }

--- a/modules/benchmark/src/test/scala/com.snowplowanalytics.snowplow.storage.bigquery.benchmark/GroupContextsBenchmark.scala
+++ b/modules/benchmark/src/test/scala/com.snowplowanalytics.snowplow.storage.bigquery.benchmark/GroupContextsBenchmark.scala
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.snowplow.storage.bigquery.benchmark
 
 import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow
-import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.implicits.idClock
+import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.clocks.idClock
 
 import org.openjdk.jmh.annotations._
 
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 class GroupContextsBenchmark {
   @Benchmark
   def groupContexts(state: States.ExampleEventState): Unit = {
-    LoaderRow.groupContexts(state.resolver, state.contexts)
+    LoaderRow.groupContexts(state.resolver, state.fieldCache, state.contexts)
     ()
   }
 }

--- a/modules/benchmark/src/test/scala/com.snowplowanalytics.snowplow.storage.bigquery.benchmark/States.scala
+++ b/modules/benchmark/src/test/scala/com.snowplowanalytics.snowplow.storage.bigquery.benchmark/States.scala
@@ -24,7 +24,8 @@ object States {
     val unstruct         = baseEvent.copy(unstruct_event = SpecHelpers.events.adClickUnstructEvent)
     val contexts         = SpecHelpers.events.geoContexts
     val resolver         = SpecHelpers.iglu.resolver
+    val fieldCache       = SpecHelpers.cache.fieldCache
     val processor        = SpecHelpers.meta.processor
-    val idClock          = SpecHelpers.implicits.idClock
+    val idClock          = SpecHelpers.clocks.idClock
   }
 }

--- a/modules/benchmark/src/test/scala/com.snowplowanalytics.snowplow.storage.bigquery.benchmark/TransformJsonBenchmark.scala
+++ b/modules/benchmark/src/test/scala/com.snowplowanalytics.snowplow.storage.bigquery.benchmark/TransformJsonBenchmark.scala
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.snowplow.storage.bigquery.benchmark
 
 import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow
-import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.implicits.idClock
+import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.clocks.idClock
 
 import cats.Id
 import org.openjdk.jmh.annotations._
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit
 class TransformJsonBenchmark {
   @Benchmark
   def transformJson(state: States.ExampleEventState): Unit = {
-    LoaderRow.transformJson[Id](state.resolver, state.adClickSchemaKey)(state.unstruct.unstruct_event.data.get.data)
+    LoaderRow.transformJson[Id](state.resolver, state.fieldCache, state.adClickSchemaKey)(state.unstruct.unstruct_event.data.get.data)
     ()
   }
 }

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/LoaderRow.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/LoaderRow.scala
@@ -14,19 +14,21 @@ package com.snowplowanalytics.snowplow.storage.bigquery.common
 
 import com.snowplowanalytics.iglu.client.Resolver
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
-import com.snowplowanalytics.iglu.core.{SchemaKey, SelfDescribingData}
+import com.snowplowanalytics.iglu.core.{SelfDescribingData, SchemaKey}
 import com.snowplowanalytics.iglu.schemaddl.bigquery._
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.{Schema => DdlSchema}
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.circe.implicits._
 import com.snowplowanalytics.snowplow.analytics.scalasdk.Data._
 import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
-import com.snowplowanalytics.snowplow.badrows.{BadRow, Failure, FailureDetails, Payload, Processor}
-
+import com.snowplowanalytics.snowplow.badrows.{BadRow, Processor, Failure, Payload, FailureDetails}
 import cats.Monad
-import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.data.{EitherT, Validated, ValidatedNel, NonEmptyList}
 import cats.effect.Clock
 import cats.implicits._
 import com.google.api.services.bigquery.model.TableRow
+import com.snowplowanalytics.iglu.client.resolver.Resolver.ResolverResult
+import com.snowplowanalytics.iglu.client.resolver.StorageTime
+import com.snowplowanalytics.snowplow.badrows.FailureDetails.LoaderIgluError
 import io.circe.{Encoder, Json}
 import io.circe.generic.semiauto._
 import io.circe.syntax._
@@ -47,29 +49,31 @@ object LoaderRow {
     * it will return a BadRow with a detailed error message.
     * If this preliminary check was passed, but the row cannot be loaded for other reasons,
     * it will be forwarded to a "failed inserts" topic, without additional information.
-    * @param igluClient A Resolver to be used for schema lookups.
+    * @param resolver A Resolver to be used for schema lookups.
     * @param record An enriched TSV line.
     * @return Either a BadRow with error messages or a row that is ready to be loaded.
     */
-  def parse[F[_]: Monad: RegistryLookup: Clock](igluClient: Resolver[F], processor: Processor)(
+  def parse[F[_]: Monad: RegistryLookup: Clock](resolver: Resolver[F], processor: Processor, fieldCache: FieldCache[F])(
     record: String
   ): F[Either[BadRow, LoaderRow]] =
     Event.parse(record) match {
       case Validated.Valid(event) =>
-        fromEvent[F](igluClient, processor)(event)
+        fromEvent[F](resolver, processor, fieldCache)(event)
       case Validated.Invalid(error) =>
         val badRowError = BadRow.LoaderParsingError(processor, error, Payload.RawPayload(record))
         Monad[F].pure(badRowError.asLeft)
     }
 
   /** Parse JSON object provided by Snowplow Analytics SDK */
-  def fromEvent[F[_]: Monad: RegistryLookup: Clock](igluClient: Resolver[F], processor: Processor)(
-    event: Event
-  ): F[Either[BadRow, LoaderRow]] = {
+  def fromEvent[F[_]: Monad: RegistryLookup: Clock](
+    resolver: Resolver[F],
+    processor: Processor,
+    fieldCache: FieldCache[F]
+  )(event: Event): F[Either[BadRow, LoaderRow]] = {
     val atomic                   = transformAtomic(event)
-    val contexts: F[Transformed] = groupContexts[F](igluClient, event.contexts.data.toVector)
+    val contexts: F[Transformed] = groupContexts[F](resolver, fieldCache, event.contexts.data.toVector)
     val derivedContexts: F[Transformed] =
-      groupContexts(igluClient, event.derived_contexts.data.toVector)
+      groupContexts(resolver, fieldCache, event.derived_contexts.data.toVector)
 
     val selfDescribingEvent: F[Transformed] = event
       .unstruct_event
@@ -77,7 +81,7 @@ object LoaderRow {
       .map {
         case SelfDescribingData(schema, data) =>
           val columnName = Schema.getColumnName(ShreddedType(UnstructEvent, schema))
-          transformJson[F](igluClient, schema)(data).map(_.map { row =>
+          transformJson[F](resolver, fieldCache, schema)(data).map(_.map { row =>
             List((columnName, Adapter.adaptRow(row)))
           })
       }
@@ -135,14 +139,16 @@ object LoaderRow {
 
   /** Group list of contexts by their full URI and transform values into ready to load rows */
   def groupContexts[F[_]: Monad: RegistryLookup: Clock](
-    igluClient: Resolver[F],
+    resolver: Resolver[F],
+    fieldCache: FieldCache[F],
     contexts: Vector[SelfDescribingData[Json]]
   ): F[ValidatedNel[FailureDetails.LoaderIgluError, List[(String, AnyRef)]]] = {
     val grouped = contexts.groupBy(_.schema).map {
       case (key, groupedContexts) =>
-        val contexts   = groupedContexts.map(_.data) // Strip away URI
-        val columnName = Schema.getColumnName(ShreddedType(Contexts(CustomContexts), key))
-        val getRow     = transformJson[F](igluClient, key)(_)
+        val contexts: Seq[Json] = groupedContexts.map(_.data) // Strip away URI
+        val columnName          = Schema.getColumnName(ShreddedType(Contexts(CustomContexts), key))
+        val getRow              = transformJson[F](resolver, fieldCache, key)(_)
+
         contexts
           .toList
           .map(getRow)
@@ -156,19 +162,49 @@ object LoaderRow {
     * Get BigQuery-compatible table rows from data-only JSON payload
     * Can be transformed to contexts (via Repeated) later only remain ue-compatible
     */
-  def transformJson[F[_]: Monad: RegistryLookup: Clock](igluClient: Resolver[F], schemaKey: SchemaKey)(
+  def transformJson[F[_]: Monad: RegistryLookup: Clock](
+    resolver: Resolver[F],
+    fieldCache: FieldCache[F],
+    schemaKey: SchemaKey
+  )(
     data: Json
-  ): F[ValidatedNel[FailureDetails.LoaderIgluError, Row]] =
-    igluClient
-      .lookupSchema(schemaKey)
-      .map(
-        _.leftMap { e =>
-          NonEmptyList.one(FailureDetails.LoaderIgluError.IgluError(schemaKey, e))
-        }.flatMap(schema => DdlSchema.parse(schema).toRight(invalidSchema(schemaKey)))
-          .map(schema => Field.build("", schema, false))
-          .flatMap(field => Row.cast(field)(data).leftMap(e => e.map(castError(schemaKey))).toEither)
-          .toValidated
-      )
+  ): F[Validated[NonEmptyList[LoaderIgluError], Row]] =
+    getSchemaAsField(resolver, schemaKey, fieldCache)
+      .value
+      .map(_.flatMap(field => Row.cast(field)(data).leftMap(e => e.map(castError(schemaKey))).toEither).toValidated)
+
+  private def schemaToField(schema: Json, schemaKey: SchemaKey): Either[NonEmptyList[LoaderIgluError], Field] =
+    DdlSchema.parse(schema).toRight(invalidSchema(schemaKey)).map(schema => Field.build("", schema, false))
+
+  private def lookupInFieldCache[F[_]: Monad](
+    fieldCache: FieldCache[F],
+    resolvedSchema: ResolverResult.Cached[SchemaKey, Json]
+  ): EitherT[F, NonEmptyList[LoaderIgluError], Field] = {
+    val fieldKey: (SchemaKey, StorageTime) = (resolvedSchema.key, resolvedSchema.timestamp)
+
+    EitherT.liftF(fieldCache.get(fieldKey)).flatMap {
+      case Some(field) => EitherT.pure[F, NonEmptyList[LoaderIgluError]](field)
+      case None => {
+        val field = schemaToField(resolvedSchema.value, resolvedSchema.key)
+        field.toEitherT[F].semiflatTap(field => fieldCache.put(fieldKey, field))
+      }
+    }
+  }
+
+  private[common] def getSchemaAsField[F[_]: Monad: RegistryLookup: Clock](
+    resolver: Resolver[F],
+    schemaKey: SchemaKey,
+    fieldCache: FieldCache[F]
+  ): EitherT[F, NonEmptyList[LoaderIgluError], Field] =
+    EitherT(resolver.lookupSchemaResult(schemaKey))
+      .leftMap(resolutionError => NonEmptyList.one(FailureDetails.LoaderIgluError.IgluError(schemaKey = schemaKey, resolutionError)))
+      .flatMap {
+        case cached: ResolverResult.Cached[SchemaKey, Json] =>
+          lookupInFieldCache(fieldCache, cached)
+        case ResolverResult.NotCached(result) => EitherT(
+          Monad[F].pure(schemaToField(result, schemaKey))
+        )
+      }
 
   def castError(schemaKey: SchemaKey)(error: CastError): FailureDetails.LoaderIgluError =
     error match {

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/package.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/package.scala
@@ -1,0 +1,11 @@
+package com.snowplowanalytics.snowplow.storage.bigquery
+
+import com.snowplowanalytics.iglu.client.resolver.StorageTime
+import com.snowplowanalytics.iglu.core.SchemaKey
+import com.snowplowanalytics.iglu.schemaddl.bigquery.Field
+import com.snowplowanalytics.lrumap.LruMap
+
+package object common {
+  type FieldKey = (SchemaKey, StorageTime)
+  type FieldCache[F[_]] = LruMap[F, FieldKey, Field]
+}

--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/CachedFieldSpec.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/CachedFieldSpec.scala
@@ -1,0 +1,120 @@
+package com.snowplowanalytics.snowplow.storage.bigquery.common
+
+import cats.data.{EitherT, NonEmptyList}
+import org.specs2.mutable.Specification
+import cats.{Id, Monad}
+import com.snowplowanalytics.iglu.client.Resolver
+import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
+import com.snowplowanalytics.snowplow.badrows.FailureDetails.LoaderIgluError
+import com.snowplowanalytics.iglu.core.SchemaKey
+import com.snowplowanalytics.iglu.schemaddl.bigquery.Field
+import com.snowplowanalytics.iglu.schemaddl.bigquery.Mode.Nullable
+import com.snowplowanalytics.iglu.schemaddl.bigquery.Type.Record
+import com.snowplowanalytics.iglu.schemaddl.bigquery.Type.String
+import com.snowplowanalytics.iglu.schemaddl.bigquery.Type.Integer
+import com.snowplowanalytics.lrumap.CreateLruMap
+import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow.getSchemaAsField
+import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.iglu._
+import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.clocks.stoppedTimeClock
+
+import scala.concurrent.duration._
+
+class CachedFieldSpec extends Specification {
+  val fieldForOriginalSchema = Field("", Record(List(Field("field1", String, Nullable))), Nullable)
+  val fieldForPatchedSchema =
+    Field("", Record(List(Field("field1", String, Nullable), Field("field2", Integer, Nullable))), Nullable)
+
+  val schemaKey = SchemaKey
+    .fromUri("iglu:com.snowplowanalytics.snowplow/test_schema/jsonschema/1-0-0")
+    .getOrElse(throw new Exception("invalid schema key in cached field spec"))
+
+  private def getCache: FieldCache[Id] = CreateLruMap[Id, FieldKey, Field].create(100)
+
+  private def getOriginalResolver: Resolver[Id] = resolver(staticRegistry(cachedSchemas(`original schema - 1 field`)))
+
+  private def getPatchedResolver(originalResolver: Resolver[Id]): Resolver[Id] = {
+    val newRepos = List(staticRegistry(cachedSchemas(`patched schema - 2 fields`)))
+    originalResolver.copy(repos = newRepos)
+  }
+
+  private def getFieldWithTime(resolver: Resolver[Id], fieldCache: FieldCache[Id], t: Int) =
+    getSchemaAsField(resolver, schemaKey, fieldCache)(Monad[Id], RegistryLookup[Id], stoppedTimeClock(t.toLong))
+
+  private def getResult(in: EitherT[Id, NonEmptyList[LoaderIgluError], Field]) =
+    in.value.getOrElse(throw new Exception("we expected a field to be created but something went wrong"))
+
+  "Cached fields should be in sync with cached schemas/lists in iglu client" >> {
+
+    "(1) original schema only, 1 field cached" in {
+      val fieldCache = getCache
+      val resolver   = getOriginalResolver
+
+      val result = getResult(getFieldWithTime(resolver, fieldCache, 1000))
+
+      result must beEqualTo(fieldForOriginalSchema)
+
+      //Field is cached after first call (1 second)
+      fieldCache.get((schemaKey, 1.second)) must beSome
+    }
+
+    "(2) original schema is patched between calls, no delay => original schema is still cached => 1 field in cache" in {
+      val fieldCache       = getCache
+      val originalResolver = getOriginalResolver
+      val patchedResolver  = getPatchedResolver(originalResolver)
+
+      //first call
+      getFieldWithTime(originalResolver, fieldCache, 1000)
+
+      //second call, same time
+      val result = getResult(getFieldWithTime(patchedResolver, fieldCache, 1000))
+
+      //no data from patched schema
+      result must beEqualTo(fieldForOriginalSchema)
+
+      //Field is cached after first call (1 second)
+      fieldCache.get((schemaKey, 1.second)) must beSome
+    }
+
+    "(3) schema is patched, delay between getSchemaAsField calls is less than cache TTL => original schema is still cached => 1 field cached" in {
+      val fieldCache       = getCache
+      val originalResolver = getOriginalResolver
+      val patchedResolver  = getPatchedResolver(originalResolver)
+
+      //first call
+      getFieldWithTime(originalResolver, fieldCache, 1000)
+
+      //second call, 2s later, less than 10s TTL
+      val result = getResult(getFieldWithTime(patchedResolver, fieldCache, 3000))
+
+      //no data from patched schema
+      result must beEqualTo(fieldForOriginalSchema)
+
+      //Field cached after first call (1 second)
+      fieldCache.get((schemaKey, 1.second)) must beSome
+
+      //Field is not cached after second call (3 seconds)
+      fieldCache.get((schemaKey, 3.second)) must beNone
+    }
+
+    "(4) schema is patched, delay between getSchemaAsField calls is greater than cache TTL => original schema is expired => using patched schema => 2 fields cached" in {
+      val fieldCache       = getCache
+      val originalResolver = getOriginalResolver
+      val patchedResolver  = getPatchedResolver(originalResolver)
+
+      //first call
+      getFieldWithTime(originalResolver, fieldCache, 1000)
+
+      //second call, 12s later - greater than 10s TTL
+      val result = getResult(getFieldWithTime(patchedResolver, fieldCache, 13000))
+
+      //Cache content expired, patched schema is fetched => expected field is based on the patched schema
+      result must beEqualTo(fieldForPatchedSchema)
+
+      //Field is cached after first call (1 second)
+      fieldCache.get((schemaKey, 1.second)) must beSome
+
+      //Field is cached after second call (13 seconds)
+      fieldCache.get((schemaKey, 13.second)) must beSome
+    }
+  }
+}

--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/LoaderRowSpec.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/LoaderRowSpec.scala
@@ -13,31 +13,35 @@
 package com.snowplowanalytics.snowplow.storage.bigquery.common
 
 import com.snowplowanalytics.iglu.client.resolver.Resolver
-import com.snowplowanalytics.iglu.core.SchemaKey
-import com.snowplowanalytics.iglu.core.SchemaVer.Full
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaMap}
 import com.snowplowanalytics.iglu.schemaddl.bigquery.Row.{Primitive, Record, Repeated}
 import com.snowplowanalytics.snowplow.badrows.Processor
 import com.snowplowanalytics.snowplow.storage.bigquery.common.Adapter._
 import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow.{LoadTstampField, transformJson}
-import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.implicits.idClock
-
+import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.clocks.idClock
 import cats.Id
 import com.google.api.services.bigquery.model.TableRow
+import com.snowplowanalytics.iglu.client.resolver.registries.Registry
+import com.snowplowanalytics.iglu.core.SchemaVer.Full
+import io.circe.Json
 import io.circe.literal._
 import io.circe.parser.parse
 import org.joda.time.Instant
 import org.specs2.mutable.Specification
 
 class LoaderRowSpec extends Specification {
-  val processor: Processor   = SpecHelpers.meta.processor
-  val resolver: Resolver[Id] = SpecHelpers.iglu.resolver
+  val processor: Processor          = SpecHelpers.meta.processor
+  val schemas: Map[SchemaMap, Json] = SpecHelpers.iglu.schemas
+  val registry: Registry            = SpecHelpers.iglu.staticRegistry(schemas)
+  val resolver: Resolver[Id]        = SpecHelpers.iglu.resolver(registry)
+  val fieldCache: FieldCache[Id]    = SpecHelpers.cache.fieldCache
 
   "groupContexts" should {
     "group contexts with same version" in {
       val contexts = SpecHelpers.events.geoContexts
 
       val result = LoaderRow
-        .groupContexts(resolver, contexts)
+        .groupContexts(resolver, fieldCache, contexts)
         .toEither
         .map(x => x.map { case (k, v) => (k, v.asInstanceOf[java.util.List[String]].size()) }.toMap)
 
@@ -98,13 +102,13 @@ class LoaderRowSpec extends Specification {
       )
 
       // OUTPUTS
-      val resultPlain = LoaderRow.fromEvent(resolver, processor)(inputPlain)
-      val resultC     = LoaderRow.fromEvent(resolver, processor)(inputC)
-      val resultDc    = LoaderRow.fromEvent(resolver, processor)(inputDc)
-      val resultUe    = LoaderRow.fromEvent(resolver, processor)(inputUe)
-      val resultUeC   = LoaderRow.fromEvent(resolver, processor)(inputUeC)
-      val resultUeDc  = LoaderRow.fromEvent(resolver, processor)(inputUeDc)
-      val resultUeDcC = LoaderRow.fromEvent(resolver, processor)(inputUeDcC)
+      val resultPlain = LoaderRow.fromEvent(resolver, processor, fieldCache)(inputPlain)
+      val resultC     = LoaderRow.fromEvent(resolver, processor, fieldCache)(inputC)
+      val resultDc    = LoaderRow.fromEvent(resolver, processor, fieldCache)(inputDc)
+      val resultUe    = LoaderRow.fromEvent(resolver, processor, fieldCache)(inputUe)
+      val resultUeC   = LoaderRow.fromEvent(resolver, processor, fieldCache)(inputUeC)
+      val resultUeDc  = LoaderRow.fromEvent(resolver, processor, fieldCache)(inputUeDc)
+      val resultUeDcC = LoaderRow.fromEvent(resolver, processor, fieldCache)(inputUeDcC)
 
       // EXPECTATIONS
       val cValue  = adaptRow(Repeated(List(Record(List(("id", Primitive("deadbeef-0000-1111-2222-deadbeef3333")))))))
@@ -180,7 +184,7 @@ class LoaderRowSpec extends Specification {
 
       // format: off
       val tstamp = event.collector_tstamp.toEpochMilli
-      
+
       val expectedPlain = LoaderRow(new Instant(tstamp), tableRowPlain, inputPlain.inventory)
       val expectedC     = LoaderRow(new Instant(tstamp), tableRowC, inputC.inventory)
       val expectedDc    = LoaderRow(new Instant(tstamp), tableRowDc, inputDc.inventory)
@@ -207,6 +211,7 @@ class LoaderRowSpec extends Specification {
       val result =
         transformJson(
           resolver,
+          fieldCache,
           SchemaKey("com.snowplowanalytics.snowplow", "nullable_array_event", "jsonschema", Full(1, 0, 0))
         )(json).toEither
 
@@ -216,7 +221,7 @@ class LoaderRowSpec extends Specification {
 
   "parse" should {
     "succeed with an event whose schema has an [array, null] property" in {
-      LoaderRow.parse(resolver, processor)(SpecHelpers.events.nullableArrayUnstructEvent) must beRight
+      LoaderRow.parse(resolver, processor, fieldCache)(SpecHelpers.events.nullableArrayUnstructEvent) must beRight
     }
   }
 }

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/loader/Loader.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/loader/Loader.scala
@@ -163,7 +163,8 @@ object Loader {
     */
   private def parse(resolverJson: Json)(record: String): Either[BadRow, LoaderRow] = {
     val resolver = singleton.ResolverSingleton.get(resolverJson)
-    LoaderRow.parse[Id](resolver, processor)(record)
+    val lookup = singleton.FieldLookupSingleton.get(resolverJson)
+    LoaderRow.parse[Id](resolver, processor, lookup)(record)
   }
 
   private def updateMetrics(cTstamp: Instant, monitoring: Monitoring) = monitoring match {

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/loader/singleton.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/loader/singleton.scala
@@ -12,9 +12,12 @@
  */
 package com.snowplowanalytics.snowplow.storage.bigquery.loader
 
-import com.snowplowanalytics.iglu.client.Resolver
-
 import cats.Id
+import com.snowplowanalytics.iglu.client.Resolver
+import com.snowplowanalytics.iglu.client.resolver.Resolver.parseConfig
+import com.snowplowanalytics.iglu.schemaddl.bigquery.Field
+import com.snowplowanalytics.lrumap.CreateLruMap
+import com.snowplowanalytics.snowplow.storage.bigquery.common.{FieldCache, FieldKey}
 import io.circe.Json
 
 object singleton {
@@ -29,6 +32,22 @@ object singleton {
         synchronized {
           if (instance == null) {
             instance = Resolver.parse[Id](r).fold(e => throw new RuntimeException(e.toString), identity)
+          }
+        }
+      }
+      instance
+    }
+  }
+
+  object FieldLookupSingleton {
+    @volatile private var instance: FieldCache[Id] = _
+
+    def get(r: Json): FieldCache[Id] = {
+      val cacheSize = parseConfig(r).map(_.cacheSize).getOrElse(500)
+      if (instance == null) {
+        synchronized {
+          if (instance == null) {
+            instance = CreateLruMap[Id, FieldKey, Field].create(cacheSize)
           }
         }
       }

--- a/modules/mutator/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/mutator/Mutator.scala
+++ b/modules/mutator/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/mutator/Mutator.scala
@@ -12,14 +12,15 @@
  */
 package com.snowplowanalytics.snowplow.storage.bigquery.mutator
 
-import com.snowplowanalytics.iglu.client.{Client, ClientError}
+import com.snowplowanalytics.iglu.client.ClientError
+import com.snowplowanalytics.iglu.client.resolver.Resolver
 import com.snowplowanalytics.iglu.core.SchemaKey
 import com.snowplowanalytics.iglu.schemaddl.bigquery.{Mode, Field => DdlField}
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.circe.implicits._
 import com.snowplowanalytics.snowplow.analytics.scalasdk.Data
 import com.snowplowanalytics.snowplow.analytics.scalasdk.Data.ShreddedType
-import com.snowplowanalytics.snowplow.storage.bigquery.common.{Adapter, Schema => LoaderSchema, LoaderRow}
+import com.snowplowanalytics.snowplow.storage.bigquery.common.{Adapter, LoaderRow, Schema => LoaderSchema}
 import com.snowplowanalytics.snowplow.storage.bigquery.common.config.Environment.MutatorEnvironment
 
 import cats.data.EitherT
@@ -39,7 +40,7 @@ import scala.util.control.NonFatal
   * Mutator is stateful worker that emits `alter table` requests.
   * It does not depend on any source of requests (such as PubSub topic)
   *
-  * @param igluClient iglu resolver, responsible for fetching schemas
+  * @param resolver iglu resolver, responsible for fetching schemas
   * @param tableReference object responsible for table interactions
   * @param state current state of the table, source of truth
   */
@@ -57,6 +58,12 @@ object Mutator {
   def filterFields(existingColumns: Vector[String], newItems: List[ShreddedType]): List[ShreddedType] =
     newItems.filterNot(item => existingColumns.contains(LoaderSchema.getColumnName(item)))
 
+  private def mkResolver(igluConfig: Json): EitherT[IO, String, Resolver[IO]] =
+    EitherT
+      .fromEither[IO](Resolver.parseConfig(igluConfig))
+      .flatMap(conf => Resolver.fromConfig[IO](conf))
+      .leftMap(failure => failure.show)
+
   def initialize(
     env: MutatorEnvironment,
     verbose: Boolean
@@ -68,13 +75,13 @@ object Mutator {
         env.config.output.good.datasetId,
         env.config.output.good.tableId
       )
-      fields     <- EitherT.liftF(table.getFields)
-      igluClient <- Client.parseDefault[IO](env.resolverJson).leftMap(_.show)
-      _          <- EitherT.liftF[IO, String, Unit](addField(table, LoaderRow.LoadTstampField))
-      ref        <- EitherT.liftF(Ref.of(MutatorState(fields, 0)))
-    } yield pipe(igluClient, table, ref, verbose)
+      fields   <- EitherT.liftF(table.getFields)
+      resolver <- mkResolver(env.resolverJson)
+      _        <- EitherT.liftF[IO, String, Unit](addField(table, LoaderRow.LoadTstampField))
+      ref      <- EitherT.liftF(Ref.of(MutatorState(fields, 0)))
+    } yield pipe(resolver, table, ref, verbose)
 
-  def pipe(igluClient: Client[IO, Json], tableReference: TableReference, ref: Ref[IO, MutatorState], verbose: Boolean)(
+  def pipe(resolver: Resolver[IO], tableReference: TableReference, ref: Ref[IO, MutatorState], verbose: Boolean)(
     implicit logger: Logger[IO]
   ): Pipe[IO, List[ShreddedType], Unit] =
     in =>
@@ -90,7 +97,7 @@ object Mutator {
         state <- Stream.eval(ref.get)
         existingColumns = state.fields.map(_.getName)
         fieldsToAdd     = filterFields(existingColumns, inventoryItems)
-        state <- Stream.eval(fieldsToAdd.foldLeftM(state)(addShreddedType(tableReference, igluClient, _, _)))
+        state <- Stream.eval(fieldsToAdd.foldLeftM(state)(addShreddedType(tableReference, resolver, _, _)))
         state <- Stream.emit(state.increment)
         _     <- Stream.eval(if (state.received % 100 == 0) logState(state) else IO.unit)
         _     <- Stream.eval(ref.set(state))
@@ -99,12 +106,12 @@ object Mutator {
   /** Perform ALTER TABLE */
   def addShreddedType(
     tableReference: TableReference,
-    igluClient: Client[IO, Json],
+    resolver: Resolver[IO],
     state: MutatorState,
     inventoryItem: ShreddedType
   )(implicit logger: Logger[IO]): IO[MutatorState] = {
     val result = for {
-      schema <- getSchema(igluClient, inventoryItem.schemaKey)
+      schema <- getSchema(resolver, inventoryItem.schemaKey)
       field = getField(inventoryItem, schema)
       _ <- tableReference.addField(field)
       _ <- logger.info(s"Added ${field.getName}")
@@ -136,9 +143,9 @@ object Mutator {
   }
 
   /** Receive the JSON Schema from the Iglu registry */
-  def getSchema(igluClient: Client[IO, Json], key: SchemaKey)(implicit logger: Logger[IO]): IO[Schema] = {
+  def getSchema(resolver: Resolver[IO], key: SchemaKey)(implicit logger: Logger[IO]): IO[Schema] = {
     val action = for {
-      response <- EitherT(igluClient.resolver.lookupSchema(key).timeout(10.seconds)).leftMap(fetchError)
+      response <- EitherT(resolver.lookupSchema(key).timeout(10.seconds)).leftMap(fetchError)
       _        <- EitherT.liftF(logger.info(s"Received schema from Iglu registry: ${response.noSpaces}"))
       schema   <- EitherT.fromOption[IO](Schema.parse(response), invalidSchema(key))
     } yield schema

--- a/modules/streamloader/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/streamloader/StreamLoader.scala
+++ b/modules/streamloader/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/streamloader/StreamLoader.scala
@@ -15,7 +15,7 @@ package com.snowplowanalytics.snowplow.storage.bigquery.streamloader
 import com.snowplowanalytics.iglu.client.Resolver
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
 import com.snowplowanalytics.snowplow.badrows.{BadRow, Processor}
-import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow
+import com.snowplowanalytics.snowplow.storage.bigquery.common.{LoaderRow, FieldCache}
 import com.snowplowanalytics.snowplow.storage.bigquery.common.config.Environment.LoaderEnvironment
 
 import cats.Monad
@@ -46,7 +46,7 @@ object StreamLoader {
   def run[F[_]: Async: Logger](e: LoaderEnvironment): F[ExitCode] =
     Resources.acquire(e).use { resources =>
       implicit val rl: RegistryLookup[F] = resources.registryLookup
-      val eventStream                    = resources.source.evalMap(parse(resources.igluClient.resolver))
+      val eventStream                    = resources.source.evalMap(parse(resources.resolver, resources.fieldCache))
 
       val sink: Pipe[F, Parsed[F], Nothing] = _.observeEither(
         resources.badSink,
@@ -73,8 +73,8 @@ object StreamLoader {
     }
 
   /** Parse a PubSub message into a `LoaderRow` (or `BadRow`) and attach `ack` action to be used after sink. */
-  def parse[F[_]: Clock: Monad: RegistryLookup](igluClient: Resolver[F])(payload: Payload[F]): F[Parsed[F]] =
-    LoaderRow.parse[F](igluClient, processor)(payload.value).map {
+  def parse[F[_]: Clock: Monad: RegistryLookup](resolver: Resolver[F], fieldCache: FieldCache[F])(payload: Payload[F]): F[Parsed[F]] =
+    LoaderRow.parse[F](resolver, processor, fieldCache)(payload.value).map {
       case Right(row) => StreamLoaderRow[F](row, payload.ack).asRight[StreamBadRow[F]]
       case Left(row)  => StreamBadRow[F](row, payload.ack).asLeft[StreamLoaderRow[F]]
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,7 +49,7 @@ object Dependencies {
     // Scala Snowplow
     val analyticsSdk = "2.1.0"
     val badrows      = "2.2.0"
-    val igluClient   = "2.1.0"
+    val igluClient   = "2.2.0"
     val igluCore     = "1.0.1"
     val schemaDdl    = "0.14.4"
 


### PR DESCRIPTION
See: https://github.com/snowplow-incubator/snowplow-bigquery-loader/issues/316

In this change, we are re-introducing a Field cache. We expect that for a given schema key, that its corresponding Field remains the same unless the schema has changed. Without the cache we compute the Field for each event that we need to load into Big Query. 

We discourage patching schemas in PROD (more detail in our docs [here](https://docs.snowplowanalytics.com/docs/understanding-tracking-design/versioning-your-data-structures/#should-i-choose-breaking-or-non-breaking)). Changes to the schema should mean a change to the schema version. Still, sometimes customers have a specific need to patch a schema in PROD, and will typically get support involved to do this.

This change aims to ensure functionality to support patched schemas does not degrade after introducing the cache:

- Changes that are currently [breaking changes](https://docs.snowplowanalytics.com/docs/understanding-tracking-design/versioning-your-data-structures/#should-i-choose-breaking-or-non-breaking) will still be breaking changes and it is still not possible to support these via patching.

- Patches should be eventually (how long it takes depends on the TTL) picked up and reflected in the data stored in big query if 1) the table's schema is manually updated to reflect the change that was introduced to the patched schema and 2) the change doesn’t make currently stored data invalid (e.g. adding an optional field, making a required field optional, changing the size of a field).

Here is how I checked that patching a schema to add a field worked as expected:

1. Brought up a sandbox gcp_rt_pipeline and ensured that [use_dev_server](https://consul.snplow.net/ui/eu-central-1/kv/customer/gcp_sandbox/gcp_rt_pipeline_leighan/input/iglu/use_dev_server/edit) was set to true

1. Brought up a sandbox gbp_bq_loader and set version to 1.5.3-rc1

1. Defined a schema for testing with a request like [this](https://gist.github.com/lmath/4add39db29efccca872cfb9c48189157)

1. Sent this [test](https://gist.github.com/lmath/b7b427111d7f8993c396369e906061e4) event that includes the required field and an optional field version.

1. Patched the schema to add another optional field like [this](https://gist.github.com/lmath/08d1affda7a70c07adacfd6f43e5ccc7).

1. Sent this [test](https://gist.github.com/lmath/dd5a619ce2f7c6dc2380acaa9647bc77) event that includes the required field and an optional field version and an optional description.

1. Checked that events came through with identical data but different timestamps by running `SELECT * FROM engineering-sandbox.rt_pipeline_leighan.events WHERE DATE(collector_tstamp) = "2022-11-23" LIMIT 100`. 

1. Added the field to the table by getting a schema file: `bq show --schema --format=prettyjson engineering-sandbox:rt_pipeline_leighan.events > schema_file`  then editing it, and applying the change `bq update engineering-sandbox:rt_pipeline_leighan.events schema_file`

1. Waited to allow for the Field in the cache to expire and resent the [test event](https://gist.github.com/lmath/dd5a619ce2f7c6dc2380acaa9647bc77) with all three fields.

1. Checked that this description field got populated 

![image](https://user-images.githubusercontent.com/3072877/203750153-32813fa4-b621-43ef-bcce-b20288d836b8.png)

