### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 1.5.1 (2022-10-04)
+--------------------------
+Bump scala version to 2.13.9 (#311)
+
 Version 1.5.0 (2022-09-26)
 --------------------------
 Stream Loader: Add Flow Control (#307)

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/LoaderRow.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/LoaderRow.scala
@@ -117,7 +117,7 @@ object LoaderRow {
             .fold(
               s"null in $key".invalidNel,
               b => b.validNel,
-              i => i.toInt.orElse(i.toBigDecimal).getOrElse(i.toDouble).validNel,
+              i => i.toInt.orElse[Any](i.toBigDecimal).getOrElse(i.toDouble).validNel,
               s => s.validNel,
               _ => s"array ${value.noSpaces} in $key".invalidNel,
               _ => s"object ${value.noSpaces} in $key".invalidNel

--- a/modules/repeater/src/main/scala/com.snowplowanalytics.snowplow.storage.bigquery.repeater/EventContainer.scala
+++ b/modules/repeater/src/main/scala/com.snowplowanalytics.snowplow.storage.bigquery.repeater/EventContainer.scala
@@ -75,7 +75,7 @@ object EventContainer {
     json.fold(
       null,
       b => b,
-      i => i.toInt.orElse(i.toBigInt.map(_.bigInteger)).getOrElse(i.toDouble),
+      i => i.toInt.orElse[Any](i.toBigInt.map(_.bigInteger)).getOrElse(i.toDouble),
       s => s,
       a => decomposeArray(a),
       o => decomposeObject(o)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -29,7 +29,7 @@ import sbtdynver.DynVerPlugin.autoImport._
 object BuildSettings {
   lazy val projectSettings = Seq(
     organization := "com.snowplowanalytics",
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.9",
     buildInfoKeys := Seq[BuildInfoKey](organization, name, version, description, BuildInfoKey.action("userAgent") {
       s"${name.value}/${version.value}"
     }),


### PR DESCRIPTION
This required adding hints for the compiler in two calls to `Option.orElse` to avoid fatal warnings.