### PR TITLE
Use in-memory registry in CachedFieldSpec

### DIFF
--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/CachedFieldSpec.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/CachedFieldSpec.scala
@@ -1,75 +1,55 @@
 package com.snowplowanalytics.snowplow.storage.bigquery.common
 
+import cats.data.{EitherT, NonEmptyList}
 import org.specs2.mutable.Specification
 import cats.{Id, Monad}
 import com.snowplowanalytics.iglu.client.Resolver
-import com.snowplowanalytics.iglu.client.resolver.registries.RegistryError.NotFound
-import com.snowplowanalytics.iglu.client.resolver.registries.{RegistryError, Registry, RegistryLookup}
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaList}
+import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
+import com.snowplowanalytics.snowplow.badrows.FailureDetails.LoaderIgluError
+import com.snowplowanalytics.iglu.core.SchemaKey
 import com.snowplowanalytics.iglu.schemaddl.bigquery.Field
 import com.snowplowanalytics.iglu.schemaddl.bigquery.Mode.Nullable
 import com.snowplowanalytics.iglu.schemaddl.bigquery.Type.Record
 import com.snowplowanalytics.iglu.schemaddl.bigquery.Type.String
 import com.snowplowanalytics.iglu.schemaddl.bigquery.Type.Integer
 import com.snowplowanalytics.lrumap.CreateLruMap
-import io.circe.Json
-import io.circe.literal.JsonStringContext
+import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow.getSchemaAsField
+import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.iglu._
+import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.clocks.stoppedTimeClock
 
 import scala.concurrent.duration._
+
 class CachedFieldSpec extends Specification {
-  //single 'field1' field
-  val `original schema - 1 field`: Json =
-    json"""
-         {
-             "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-             "description": "Test schema 1",
-             "self": {
-                 "vendor": "com.snowplowanalytics.snowplow",
-                 "name": "test_schema",
-                 "format": "jsonschema",
-                 "version": "1-0-0"
-             },
-
-             "type": "object",
-             "properties": {
-               "field1": { "type": "string"}
-              }
-         }
-        """
-
-  //same key as schema1, but with additional `field2` field.
-  val `patched schema - 2 fields`: Json =
-    json"""
-         {
-             "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-             "description": "Test schema 1",
-             "self": {
-                 "vendor": "com.snowplowanalytics.snowplow",
-                 "name": "test_schema",
-                 "format": "jsonschema",
-                 "version": "1-0-0"
-             },
-
-             "type": "object",
-             "properties": {
-               "field1": { "type": "string" },
-               "field2": { "type": "integer" }
-              }
-         }
-        """
-
   val fieldForOriginalSchema = Field("", Record(List(Field("field1", String, Nullable))), Nullable)
-  val fieldForPatchedSchema = Field("", Record(List(Field("field1", String, Nullable), Field("field2", Integer, Nullable))), Nullable)
+  val fieldForPatchedSchema =
+    Field("", Record(List(Field("field1", String, Nullable), Field("field2", Integer, Nullable))), Nullable)
 
-  val schemaKey = SchemaKey.fromUri("iglu:com.snowplowanalytics.snowplow/test_schema/jsonschema/1-0-0").getOrElse(throw new Exception("invalid schema key in cached field spec"))
+  val schemaKey = SchemaKey
+    .fromUri("iglu:com.snowplowanalytics.snowplow/test_schema/jsonschema/1-0-0")
+    .getOrElse(throw new Exception("invalid schema key in cached field spec"))
+
+  private def getCache: FieldCache[Id] = CreateLruMap[Id, FieldKey, Field].create(100)
+
+  private def getOriginalResolver: Resolver[Id] = resolver(staticRegistry(cachedSchemas(`original schema - 1 field`)))
+
+  private def getPatchedResolver(originalResolver: Resolver[Id]): Resolver[Id] = {
+    val newRepos = List(staticRegistry(cachedSchemas(`patched schema - 2 fields`)))
+    originalResolver.copy(repos = newRepos)
+  }
+
+  private def getFieldWithTime(resolver: Resolver[Id], fieldCache: FieldCache[Id], t: Int) =
+    getSchemaAsField(resolver, schemaKey, fieldCache)(Monad[Id], RegistryLookup[Id], stoppedTimeClock(t.toLong))
+
+  private def getResult(in: EitherT[Id, NonEmptyList[LoaderIgluError], Field]) =
+    in.value.getOrElse(throw new Exception("we expected a field to be created but something went wrong"))
 
   "Cached fields should be in sync with cached schemas/lists in iglu client" >> {
 
     "(1) original schema only, 1 field cached" in {
       val fieldCache = getCache
-      val resolver = getResolver
+      val resolver   = getOriginalResolver
 
-      val result = getSchemaAsField(resolver, fieldCache)(schemaInRegistry = `original schema - 1 field`, timeInMs = 1000)
+      val result = getResult(getFieldWithTime(resolver, fieldCache, 1000))
 
       result must beEqualTo(fieldForOriginalSchema)
 
@@ -78,14 +58,15 @@ class CachedFieldSpec extends Specification {
     }
 
     "(2) original schema is patched between calls, no delay => original schema is still cached => 1 field in cache" in {
-      val fieldCache = getCache
-      val resolver = getResolver
+      val fieldCache       = getCache
+      val originalResolver = getOriginalResolver
+      val patchedResolver  = getPatchedResolver(originalResolver)
 
       //first call
-      getSchemaAsField(resolver, fieldCache)(schemaInRegistry = `original schema - 1 field`, timeInMs = 1000)
+      getFieldWithTime(originalResolver, fieldCache, 1000)
 
       //second call, same time
-      val result = getSchemaAsField(resolver, fieldCache)(schemaInRegistry = `patched schema - 2 fields`, timeInMs = 1000)
+      val result = getResult(getFieldWithTime(patchedResolver, fieldCache, 1000))
 
       //no data from patched schema
       result must beEqualTo(fieldForOriginalSchema)
@@ -95,14 +76,15 @@ class CachedFieldSpec extends Specification {
     }
 
     "(3) schema is patched, delay between getSchemaAsField calls is less than cache TTL => original schema is still cached => 1 field cached" in {
-      val fieldCache = getCache
-      val resolver = getResolver
+      val fieldCache       = getCache
+      val originalResolver = getOriginalResolver
+      val patchedResolver  = getPatchedResolver(originalResolver)
 
       //first call
-      getSchemaAsField(resolver, fieldCache)(schemaInRegistry = `original schema - 1 field`, timeInMs = 1000)
+      getFieldWithTime(originalResolver, fieldCache, 1000)
 
       //second call, 2s later, less than 10s TTL
-      val result = getSchemaAsField(resolver, fieldCache)(schemaInRegistry = `patched schema - 2 fields`, timeInMs = 3000)
+      val result = getResult(getFieldWithTime(patchedResolver, fieldCache, 3000))
 
       //no data from patched schema
       result must beEqualTo(fieldForOriginalSchema)
@@ -115,14 +97,15 @@ class CachedFieldSpec extends Specification {
     }
 
     "(4) schema is patched, delay between getSchemaAsField calls is greater than cache TTL => original schema is expired => using patched schema => 2 fields cached" in {
-      val fieldCache = getCache
-      val resolver = getResolver
+      val fieldCache       = getCache
+      val originalResolver = getOriginalResolver
+      val patchedResolver  = getPatchedResolver(originalResolver)
 
       //first call
-      getSchemaAsField(resolver, fieldCache)(schemaInRegistry = `original schema - 1 field`, timeInMs = 1000)
+      getFieldWithTime(originalResolver, fieldCache, 1000)
 
       //second call, 12s later - greater than 10s TTL
-      val result = getSchemaAsField(resolver, fieldCache)(schemaInRegistry = `patched schema - 2 fields`, timeInMs = 13000)
+      val result = getResult(getFieldWithTime(patchedResolver, fieldCache, 13000))
 
       //Cache content expired, patched schema is fetched => expected field is based on the patched schema
       result must beEqualTo(fieldForPatchedSchema)
@@ -133,36 +116,5 @@ class CachedFieldSpec extends Specification {
       //Field is cached after second call (13 seconds)
       fieldCache.get((schemaKey, 13.second)) must beSome
     }
-  }
-
-  //Helper method to wire all test dependencies and execute LoaderRow.getSchemaAsField
-  private def getSchemaAsField(resolver: Resolver[Id], fieldCache: FieldCache[Id])(schemaInRegistry: Json, timeInMs: Long) = {
-
-    //To return value stored in the schemaInRegistry variable, passed registry is ignored
-    val testRegistryLookup: RegistryLookup[Id] = new RegistryLookup[Id] {
-      override def lookup(registry: Registry, schemaKey: SchemaKey): Id[Either[RegistryError, Json]] = Right(schemaInRegistry)
-
-      override def list(registry: Registry,
-                        vendor: String,
-                        name: String,
-                        model: Int): Id[Either[RegistryError, SchemaList]] = Left(NotFound) // not used
-    }
-
-    LoaderRow.getSchemaAsField[Id](resolver, schemaKey, fieldCache)(Monad[Id], testRegistryLookup, SpecHelpers.clocks.stoppedTimeClock(timeInMs))
-      .value
-      .getOrElse(throw new Exception("we expected a field to be created but something went wrong"))
-  }
-
-  private def getCache: FieldCache[Id] = CreateLruMap[Id, FieldKey, Field].create(100)
-
-  private def getResolver: Resolver[Id] = {
-    Resolver.init[Id](
-      cacheSize = 10,
-      cacheTtl = Some(10.seconds),
-      refs = Registry.Embedded( //not used in test as we fix returned schema in custom test RegistryLookup
-        Registry.Config("Test", 0, List.empty),
-        path = "/fake"
-      )
-    )
   }
 }

--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/LoaderRowSpec.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/storage/bigquery/common/LoaderRowSpec.scala
@@ -13,24 +13,28 @@
 package com.snowplowanalytics.snowplow.storage.bigquery.common
 
 import com.snowplowanalytics.iglu.client.resolver.Resolver
-import com.snowplowanalytics.iglu.core.SchemaKey
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaMap}
 import com.snowplowanalytics.iglu.schemaddl.bigquery.Row.{Primitive, Record, Repeated}
 import com.snowplowanalytics.snowplow.badrows.Processor
 import com.snowplowanalytics.snowplow.storage.bigquery.common.Adapter._
-import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow.{transformJson, LoadTstampField}
+import com.snowplowanalytics.snowplow.storage.bigquery.common.LoaderRow.{LoadTstampField, transformJson}
 import com.snowplowanalytics.snowplow.storage.bigquery.common.SpecHelpers.clocks.idClock
 import cats.Id
 import com.google.api.services.bigquery.model.TableRow
+import com.snowplowanalytics.iglu.client.resolver.registries.Registry
 import com.snowplowanalytics.iglu.core.SchemaVer.Full
+import io.circe.Json
 import io.circe.literal._
 import io.circe.parser.parse
 import org.joda.time.Instant
 import org.specs2.mutable.Specification
 
 class LoaderRowSpec extends Specification {
-  val processor: Processor   = SpecHelpers.meta.processor
-  val resolver: Resolver[Id] = SpecHelpers.iglu.resolver
-  val fieldCache: FieldCache[Id] = SpecHelpers.cache.fieldCache
+  val processor: Processor          = SpecHelpers.meta.processor
+  val schemas: Map[SchemaMap, Json] = SpecHelpers.iglu.schemas
+  val registry: Registry            = SpecHelpers.iglu.staticRegistry(schemas)
+  val resolver: Resolver[Id]        = SpecHelpers.iglu.resolver(registry)
+  val fieldCache: FieldCache[Id]    = SpecHelpers.cache.fieldCache
 
   "groupContexts" should {
     "group contexts with same version" in {


### PR DESCRIPTION
Instead of a fake embedded registry, this uses an in memory registry. I like this better because we're using the real schemas in the registry, rather than ignoring it and mocking the result. WDYT?