### PR TITLE
Bump google-cloud-bigquery version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,9 +16,9 @@ object Dependencies {
 
   object V {
     // Java
-    val googleCloudBigQuery = "2.31.1" // compatible with google-cloud-bom:0.175.0
-    val googleCloudPubSub   = "1.119.0" // compatible with google-cloud-bom:0.175.0
-    val googleCloudStorage  = "2.7.2" // compatible with google-cloud-bom:0.175.0
+    val googleCloudBigQuery = "2.31.1" // compatible with google-cloud-bom:0.203.0
+    val googleCloudPubSub   = "1.124.1" // compatible with google-cloud-bom:0.203.0
+    val googleCloudStorage  = "2.26.0" // compatible with google-cloud-bom:0.203.0
     val slf4j   = "1.7.32"
     val sentry  = "1.7.30"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
 
   object V {
     // Java
-    val googleCloudBigQuery = "2.13.0" // compatible with google-cloud-bom:0.175.0
+    val googleCloudBigQuery = "2.31.1" // compatible with google-cloud-bom:0.175.0
     val googleCloudPubSub   = "1.119.0" // compatible with google-cloud-bom:0.175.0
     val googleCloudStorage  = "2.7.2" // compatible with google-cloud-bom:0.175.0
     val slf4j   = "1.7.32"


### PR DESCRIPTION
I have run the tests, compiled, and run docker:publishLocal, and nothing seems to have broken.

I'm unsure the level of further checks we'd like to do in order to verify a bump from 2.13 -> 2.31.