### PR TITLE
Improve exception handling immediately after altering the table

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -74,11 +74,17 @@
       "delay": "30 seconds"
     }
 
-    # -- Configures exponential backoff  errors that are likely to be transient.
+    # -- Configures exponential backoff errors that are likely to be transient.
     # -- Examples include server errors and network errors
     "transientErrors": {
       "delay": "1 second"
       "attempts": 5
+    }
+
+    # -- Configures backoff when waiting for the BigQuery Writer to detect that we have altered the
+    # -- table by adding new columns
+    "alterTableWait": {
+      "delay": 1 second"
     }
   } 
 

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -96,11 +96,17 @@
       "delay": "30 seconds"
     }
 
-    # -- Configures exponential backoff  errors that are likely to be transient.
+    # -- Configures exponential backoff errors that are likely to be transient.
     # -- Examples include server errors and network errors
     "transientErrors": {
       "delay": "1 second"
       "attempts": 5
+    }
+
+    # -- Configures backoff when waiting for the BigQuery Writer to detect that we have altered the
+    # -- table by adding new columns
+    "alterTableWait": {
+      "delay": 1 second"
     }
   } 
 

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -76,11 +76,17 @@
       "delay": "30 seconds"
     }
 
-    # -- Configures exponential backoff  errors that are likely to be transient.
+    # -- Configures exponential backoff errors that are likely to be transient.
     # -- Examples include server errors and network errors
     "transientErrors": {
       "delay": "1 second"
       "attempts": 5
+    }
+
+    # -- Configures backoff when waiting for the BigQuery Writer to detect that we have altered the
+    # -- table by adding new columns
+    "alterTableWait": {
+      "delay": 1 second"
     }
   } 
 

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -27,6 +27,9 @@
       "delay": "1 second"
       "attempts": 5
     }
+    "alterTableWait": {
+      "delay": 1 second"
+    }
   }
 
   "monitoring": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
@@ -81,11 +81,13 @@ object Config {
   final case class Webhook(endpoint: Uri, tags: Map[String, String])
 
   case class SetupErrorRetries(delay: FiniteDuration)
+  case class AlterTableWaitRetries(delay: FiniteDuration)
   case class TransientErrorRetries(delay: FiniteDuration, attempts: Int)
 
   case class Retries(
     setupErrors: SetupErrorRetries,
-    transientErrors: TransientErrorRetries
+    transientErrors: TransientErrorRetries,
+    alterTableWait: AlterTableWaitRetries
   )
 
   implicit def decoder[Source: Decoder, Sink: Decoder]: Decoder[Config[Source, Sink]] = {
@@ -112,6 +114,7 @@ object Config {
     implicit val webhookDecoder     = deriveConfiguredDecoder[Webhook]
     implicit val monitoringDecoder  = deriveConfiguredDecoder[Monitoring]
     implicit val setupRetries       = deriveConfiguredDecoder[SetupErrorRetries]
+    implicit val alterTableRetries  = deriveConfiguredDecoder[AlterTableWaitRetries]
     implicit val transientRetries   = deriveConfiguredDecoder[TransientErrorRetries]
     implicit val retriesDecoder     = deriveConfiguredDecoder[Retries]
     deriveConfiguredDecoder[Config[Source, Sink]]

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/AtomicDescriptor.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/AtomicDescriptor.scala
@@ -15,17 +15,23 @@ import com.google.protobuf.{DescriptorProtos, Descriptors}
  * table
  */
 object AtomicDescriptor {
-  val get: Descriptors.Descriptor = {
 
-    val eventId = DescriptorProtos.FieldDescriptorProto.newBuilder
-      .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
-      .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
-      .setName("event_id")
-      .setNumber(1)
-
+  def get: Descriptors.Descriptor = {
     val descriptorProto = DescriptorProtos.DescriptorProto.newBuilder
-      .setName("event")
-      .addField(0, eventId) // For laziness, only adding one atomic field
+      .addField(0, eventId.setNumber(1)) // For laziness, only adding one atomic field
+    fromDescriptorProtoBuilder(descriptorProto)
+  }
+
+  def withWebPage: Descriptors.Descriptor = {
+    val descriptorProto = DescriptorProtos.DescriptorProto.newBuilder
+      .addField(0, eventId.setNumber(1))
+      .addField(1, webPage.setNumber(2))
+      .addNestedType(webPageNestedType)
+    fromDescriptorProtoBuilder(descriptorProto)
+  }
+
+  private def fromDescriptorProtoBuilder(descriptorProto: DescriptorProtos.DescriptorProto.Builder): Descriptors.Descriptor = {
+    descriptorProto.setName("event")
 
     val fdp = DescriptorProtos.FileDescriptorProto.newBuilder
       .addMessageType(descriptorProto)
@@ -34,5 +40,27 @@ object AtomicDescriptor {
     val fd = Descriptors.FileDescriptor.buildFrom(fdp, Array())
     fd.findMessageTypeByName("event")
   }
+
+  private def eventId: DescriptorProtos.FieldDescriptorProto.Builder =
+    DescriptorProtos.FieldDescriptorProto.newBuilder
+      .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+      .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+      .setName("event_id")
+
+  private def webPage: DescriptorProtos.FieldDescriptorProto.Builder = DescriptorProtos.FieldDescriptorProto.newBuilder
+    .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+    .setTypeName("web_page_1")
+    .setName("unstruct_event_com_snowplowanalytics_snowplow_web_page_1")
+
+  private def webPageId: DescriptorProtos.FieldDescriptorProto.Builder =
+    DescriptorProtos.FieldDescriptorProto.newBuilder
+      .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+      .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+      .setName("id")
+
+  private def webPageNestedType: DescriptorProtos.DescriptorProto.Builder =
+    DescriptorProtos.DescriptorProto.newBuilder
+      .addField(0, webPageId.setNumber(1))
+      .setName("web_page_1")
 
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/WriterProviderSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/WriterProviderSpec.scala
@@ -315,7 +315,11 @@ object WriterProviderSpec {
     monitoring: Monitoring[IO]
   )
 
-  val retriesConfig = Config.Retries(Config.SetupErrorRetries(30.seconds), Config.TransientErrorRetries(1.second, 5))
+  def retriesConfig = Config.Retries(
+    Config.SetupErrorRetries(30.seconds),
+    Config.TransientErrorRetries(1.second, 5),
+    Config.AlterTableWaitRetries(1.second)
+  )
 
   def control: IO[Control] =
     for {


### PR DESCRIPTION
When the BigQuery Loader encounters a new schema for the first time, it alters the table to add new columns.  But there can be a delay between adding the new column, and the column becoming available for receiving new events.

Opening a Writer is not considered successful, until it is opened in a state where it knows about the newly added column.  This commit adds a delay/backoff when opening the Writer, so it retries gracefully.