### PR TITLE
Recover from server-side schema mismatch exceptions

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQuerySchemaUtils.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQuerySchemaUtils.scala
@@ -113,4 +113,9 @@ object BigQuerySchemaUtils {
   private def bqModeOf(nullability: Type.Nullability): BQField.Mode =
     if (nullability.nullable) BQField.Mode.NULLABLE else BQField.Mode.REQUIRED
 
+  def showDescriptor(descriptor: Descriptors.Descriptor): String =
+    descriptor.getFields.asScala
+      .map(_.getName)
+      .mkString(", ")
+
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/AtomicDescriptor.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/AtomicDescriptor.scala
@@ -16,12 +16,14 @@ import com.google.protobuf.{DescriptorProtos, Descriptors}
  */
 object AtomicDescriptor {
 
-  def get: Descriptors.Descriptor = {
+  /** The initial descriptor altering table for self-describing entities */
+  def initial: Descriptors.Descriptor = {
     val descriptorProto = DescriptorProtos.DescriptorProto.newBuilder
       .addField(0, eventId.setNumber(1)) // For laziness, only adding one atomic field
     fromDescriptorProtoBuilder(descriptorProto)
   }
 
+  /** A table which has been altered to add the web_page unstruct event column */
   def withWebPage: Descriptors.Descriptor = {
     val descriptorProto = DescriptorProtos.DescriptorProto.newBuilder
       .addField(0, eventId.setNumber(1))

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/WriterProviderSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/WriterProviderSpec.scala
@@ -347,7 +347,7 @@ object WriterProviderSpec {
 
   private def testCloseableWriter(state: Ref[IO, Vector[Action]]): Writer.CloseableWriter[IO] = new Writer.CloseableWriter[IO] {
     def descriptor: IO[Descriptors.Descriptor] =
-      IO(AtomicDescriptor.get)
+      IO(AtomicDescriptor.initial)
 
     def write(rows: List[Map[String, AnyRef]]): IO[Writer.WriteResult] = IO.pure(Writer.WriteResult.Success)
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -41,7 +41,11 @@ object BuildSettings {
   )
 
   lazy val coreSettings = Seq(
-    igluUris := Seq("iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0")
+    Test / igluUris := Seq(
+      // Iglu schemas used in unit tests
+      "iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0",
+      "iglu:com.snowplowanalytics.snowplow.media/ad_start_event/jsonschema/1-0-0"
+    )
   ) ++ commonSettings
 
   lazy val appSettings = Seq(


### PR DESCRIPTION
This is about what happens immediately after altering the table to add a new column.

In #366 I amended the loader so it retries opening the Writer, until the Writer discovers the extra columns.  However, this only accounted for the **client-side** writer discovering the columns.

When running the loader, I discovered there is also an issue where the **server-side** end of the connection can be slow to discover the newly added columns.  This commit catches and retries the known exception when the server has not yet discovered the new columns.