### PR TITLE
Use common-streams 0.5.2

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -87,6 +87,14 @@
       "delay": "1 second"
     }
   } 
+  
+  # -- Schemas that won't be loaded to BigQuery. Optional, default value []
+  "skipSchemas": [
+    "iglu:com.acme/skipped1/jsonschema/1-0-0",
+    "iglu:com.acme/skipped2/jsonschema/1-0-*",
+    "iglu:com.acme/skipped3/jsonschema/1-*-*",
+    "iglu:com.acme/skipped4/jsonschema/*-*-*"
+  ]
 
   "monitoring": {
     "metrics": {

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -110,6 +110,14 @@
     }
   } 
 
+  # -- Schemas that won't be loaded to BigQuery. Optional, default value []
+  "skipSchemas": [
+    "iglu:com.acme/skipped1/jsonschema/1-0-0",
+    "iglu:com.acme/skipped2/jsonschema/1-0-*",
+    "iglu:com.acme/skipped3/jsonschema/1-*-*",
+    "iglu:com.acme/skipped4/jsonschema/*-*-*"
+  ]
+  
   "monitoring": {
     "metrics": {
 

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -90,6 +90,14 @@
     }
   } 
 
+  # -- Schemas that won't be loaded to BigQuery. Optional, default value []
+  "skipSchemas": [
+    "iglu:com.acme/skipped1/jsonschema/1-0-0",
+    "iglu:com.acme/skipped2/jsonschema/1-0-*",
+    "iglu:com.acme/skipped3/jsonschema/1-*-*",
+    "iglu:com.acme/skipped4/jsonschema/*-*-*"
+  ]
+  
   "monitoring": {
     "metrics": {
 

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -1,5 +1,10 @@
 {
 
+  license {
+    accept = false
+    accept = ${?ACCEPT_LIMITED_USE_LICENSE}
+  }
+  
   "gcpUserAgent": {
     "productName": "Snowplow OSS"
     "productName": ${?GCP_USER_AGENT_PRODUCT_NAME}
@@ -31,6 +36,8 @@
       "delay": "1 second"
     }
   }
+  
+  "skipSchemas": []
 
   "monitoring": {
     "metrics": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Alert.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Alert.scala
@@ -23,7 +23,7 @@ object Alert {
   private val MaxAlertPayloadLength = 4096
 
   final case class FailedToCreateEventsTable(cause: Throwable) extends Alert
-  final case class FailedToAddColumns(columns: List[String], cause: Throwable) extends Alert
+  final case class FailedToAddColumns(columns: Vector[String], cause: Throwable) extends Alert
   final case class FailedToOpenBigQueryWriter(cause: Throwable) extends Alert
 
   def toSelfDescribingJson(

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
@@ -18,9 +18,10 @@ import com.comcast.ip4s.Port
 import org.http4s.{ParseFailure, Uri}
 
 import scala.concurrent.duration.FiniteDuration
-
 import com.snowplowanalytics.iglu.client.resolver.Resolver.ResolverConfig
-import com.snowplowanalytics.snowplow.runtime.{Metrics => CommonMetrics, Telemetry}
+import com.snowplowanalytics.iglu.core.SchemaCriterion
+import com.snowplowanalytics.snowplow.runtime.{AcceptedLicense, Metrics => CommonMetrics, Telemetry}
+import com.snowplowanalytics.iglu.core.circe.CirceIgluCodecs.schemaCriterionDecoder
 import com.snowplowanalytics.snowplow.runtime.HealthProbe.decoders._
 
 case class Config[+Source, +Sink](
@@ -29,7 +30,9 @@ case class Config[+Source, +Sink](
   batching: Config.Batching,
   retries: Config.Retries,
   telemetry: Telemetry.Config,
-  monitoring: Config.Monitoring
+  monitoring: Config.Monitoring,
+  license: AcceptedLicense,
+  skipSchemas: List[SchemaCriterion]
 )
 
 object Config {
@@ -117,6 +120,11 @@ object Config {
     implicit val alterTableRetries  = deriveConfiguredDecoder[AlterTableWaitRetries]
     implicit val transientRetries   = deriveConfiguredDecoder[TransientErrorRetries]
     implicit val retriesDecoder     = deriveConfiguredDecoder[Retries]
+
+    // TODO add bigquery docs
+    implicit val licenseDecoder =
+      AcceptedLicense.decoder(AcceptedLicense.DocumentationLink("https://docs.snowplow.io/limited-use-license-1.0/"))
+
     deriveConfiguredDecoder[Config[Source, Sink]]
   }
 

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
@@ -15,8 +15,8 @@ import org.http4s.client.Client
 import org.http4s.blaze.client.BlazeClientBuilder
 import io.sentry.Sentry
 import retry.RetryPolicy
-
 import com.snowplowanalytics.iglu.client.resolver.Resolver
+import com.snowplowanalytics.iglu.core.SchemaCriterion
 import com.snowplowanalytics.snowplow.sources.SourceAndAck
 import com.snowplowanalytics.snowplow.sinks.Sink
 import com.snowplowanalytics.snowplow.bigquery.processing.{BigQueryRetrying, BigQueryUtils, TableManager, Writer}
@@ -34,7 +34,8 @@ case class Environment[F[_]](
   appHealth: AppHealth[F],
   alterTableWaitPolicy: RetryPolicy[F],
   batching: Config.Batching,
-  badRowMaxSize: Int
+  badRowMaxSize: Int,
+  schemasToSkip: List[SchemaCriterion]
 )
 
 object Environment {
@@ -76,7 +77,8 @@ object Environment {
       appHealth            = appHealth,
       alterTableWaitPolicy = BigQueryRetrying.policyForAlterTableWait(config.main.retries),
       batching             = config.main.batching,
-      badRowMaxSize        = config.main.output.bad.maxRecordSize
+      badRowMaxSize        = config.main.output.bad.maxRecordSize,
+      schemasToSkip        = config.main.skipSchemas
     )
 
   private def enableSentry[F[_]: Sync](appInfo: AppInfo, config: Option[Config.Sentry]): Resource[F, Unit] =

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQuerySchemaUtils.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQuerySchemaUtils.scala
@@ -16,7 +16,7 @@ import scala.jdk.CollectionConverters._
 
 object BigQuerySchemaUtils {
 
-  def alterTableRequired(tableDescriptor: Descriptors.Descriptor, ddlFields: List[Field]): Boolean =
+  def alterTableRequired(tableDescriptor: Descriptors.Descriptor, ddlFields: Seq[Field]): Boolean =
     ddlFields.exists { field =>
       Option(tableDescriptor.findFieldByName(field.name)) match {
         case Some(fieldDescriptor) =>
@@ -40,7 +40,7 @@ object BigQuerySchemaUtils {
         false
     }
 
-  def mergeInColumns(bqFields: FieldList, ddlFields: List[Field]): FieldList = {
+  def mergeInColumns(bqFields: FieldList, ddlFields: Seq[Field]): FieldList = {
     val ddlFieldsByName = ddlFields.map(f => f.name -> f).toMap
     val bqFieldNames    = bqFields.asScala.map(f => f.getName).toSet
     val alteredExisting = bqFields.asScala.map { bqField =>

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/Processing.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/Processing.scala
@@ -145,7 +145,7 @@ object Processing {
         now <- Sync[F].realTimeInstant
         loadTstamp = BigQueryCaster.timestampValue(now)
         _ <- Logger[F].debug(s"Processing batch of size ${events.size}")
-        nonAtomicFields <- NonAtomicFields.resolveTypes[F](env.resolver, entities)
+        nonAtomicFields <- NonAtomicFields.resolveTypes[F](env.resolver, entities, env.schemasToSkip)
         (moreBad, rows) <- transformBatch[F](badProcessor, loadTstamp, events, nonAtomicFields)
       } yield BatchAfterTransform(
         rows,

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/TableManager.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/TableManager.scala
@@ -34,7 +34,7 @@ import scala.jdk.CollectionConverters._
 
 trait TableManager[F[_]] {
 
-  def addColumns(columns: List[Field]): F[Unit]
+  def addColumns(columns: Vector[Field]): F[Unit]
 
   def createTable: F[Unit]
 
@@ -63,7 +63,7 @@ object TableManager {
     monitoring: Monitoring[F]
   ): TableManager[F] = new TableManager[F] {
 
-    def addColumns(columns: List[Field]): F[Unit] =
+    def addColumns(columns: Vector[Field]): F[Unit] =
       BigQueryRetrying.withRetries(appHealth, retries, monitoring, Alert.FailedToAddColumns(columns.map(_.name), _)) {
         Logger[F].info(s"Altering table to add columns [${showColumns(columns)}]") *>
           addColumnsImpl(config, client, columns)
@@ -89,7 +89,7 @@ object TableManager {
   private def addColumnsImpl[F[_]: Sync](
     config: Config.BigQuery,
     client: BigQuery,
-    columns: List[Field]
+    columns: Vector[Field]
   ): F[Unit] =
     for {
       table <- Sync[F].blocking(client.getTable(config.dataset, config.table))
@@ -113,7 +113,7 @@ object TableManager {
     // Don't do anything else; the BigQueryRetrying will handle retries and logging the exception.
   }
 
-  private def showColumns(columns: List[Field]): String =
+  private def showColumns(columns: Vector[Field]): String =
     columns.map(_.name).mkString(", ")
 
   private def atomicTableInfo(config: Config.BigQuery): TableInfo = {

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -39,7 +39,7 @@ object MockEnvironment {
     case object CreatedTable extends Action
     case class Checkpointed(tokens: List[Unique.Token]) extends Action
     case class SentToBad(count: Long) extends Action
-    case class AlterTableAddedColumns(columns: List[String]) extends Action
+    case class AlterTableAddedColumns(columns: Vector[String]) extends Action
     case object OpenedWriter extends Action
     case object ClosedWriter extends Action
     case class WroteRowsToBigQuery(rowCount: Int) extends Action
@@ -83,7 +83,8 @@ object MockEnvironment {
           maxDelay              = 10.seconds,
           writeBatchConcurrency = 1
         ),
-        badRowMaxSize = 1000000
+        badRowMaxSize = 1000000,
+        schemasToSkip = List.empty
       )
       MockEnvironment(state, env)
     }
@@ -111,7 +112,7 @@ object MockEnvironment {
   }
 
   private def testTableManager(state: Ref[IO, Vector[Action]]): TableManager[IO] = new TableManager[IO] {
-    def addColumns(columns: List[Field]): IO[Unit] =
+    def addColumns(columns: Vector[Field]): IO[Unit] =
       state.update(_ :+ AlterTableAddedColumns(columns.map(_.name)))
 
     def createTable: IO[Unit] =

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/ProcessingSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/ProcessingSpec.scala
@@ -122,7 +122,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Vector(
           Action.CreatedTable,
           Action.OpenedWriter,
-          Action.AlterTableAddedColumns(List("unstruct_event_com_snowplowanalytics_snowplow_media_ad_start_event_1")),
+          Action.AlterTableAddedColumns(Vector("unstruct_event_com_snowplowanalytics_snowplow_media_ad_start_event_1")),
           Action.ClosedWriter,
           Action.OpenedWriter,
           Action.WroteRowsToBigQuery(2),

--- a/modules/kafka/src/main/scala/com.snowplowanalytics.snowplow.bigquery/AzureApp.scala
+++ b/modules/kafka/src/main/scala/com.snowplowanalytics.snowplow.bigquery/AzureApp.scala
@@ -8,12 +8,19 @@
  */
 package com.snowplowanalytics.snowplow.bigquery
 
+import com.snowplowanalytics.snowplow.azure.AzureAuthenticationCallbackHandler
 import com.snowplowanalytics.snowplow.sources.kafka.{KafkaSource, KafkaSourceConfig}
 import com.snowplowanalytics.snowplow.sinks.kafka.{KafkaSink, KafkaSinkConfig}
 
+import scala.reflect.classTag
+
+class SourceAuthHandler extends AzureAuthenticationCallbackHandler
+
+class SinkAuthHandler extends AzureAuthenticationCallbackHandler
+
 object AzureApp extends LoaderApp[KafkaSourceConfig, KafkaSinkConfig](BuildInfo) {
 
-  override def source: SourceProvider = KafkaSource.build(_)
+  override def source: SourceProvider = KafkaSource.build(_, classTag[SourceAuthHandler])
 
-  override def badSink: SinkProvider = KafkaSink.resource(_)
+  override def badSink: SinkProvider = KafkaSink.resource(_, classTag[SinkAuthHandler])
 }

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
@@ -14,10 +14,11 @@ import cats.Id
 import cats.effect.testing.specs2.CatsEffect
 import cats.effect.{ExitCode, IO}
 import com.comcast.ip4s.Port
+import com.snowplowanalytics.iglu.core.SchemaCriterion
 import com.snowplowanalytics.snowplow.bigquery.Config.GcpUserAgent
 import com.snowplowanalytics.snowplow.pubsub.{GcpUserAgent => PubsubUserAgent}
 import com.snowplowanalytics.snowplow.runtime.Metrics.StatsdConfig
-import com.snowplowanalytics.snowplow.runtime.{ConfigParser, Telemetry}
+import com.snowplowanalytics.snowplow.runtime.{AcceptedLicense, ConfigParser, Telemetry}
 import com.snowplowanalytics.snowplow.sinks.pubsub.PubsubSinkConfig
 import com.snowplowanalytics.snowplow.sources.pubsub.PubsubSourceConfig
 import org.http4s.implicits.http4sLiteralsSyntax
@@ -115,7 +116,9 @@ object PubsubConfigSpec {
       sentry      = None,
       healthProbe = Config.HealthProbe(port = Port.fromInt(8000).get, unhealthyLatency = 5.minutes),
       webhook     = None
-    )
+    ),
+    license     = AcceptedLicense(),
+    skipSchemas = List.empty
   )
 
   private val extendedConfig = Config[PubsubSourceConfig, PubsubSinkConfig](
@@ -187,6 +190,13 @@ object PubsubConfigSpec {
         unhealthyLatency = 5.minutes
       ),
       webhook = Some(Config.Webhook(endpoint = uri"https://webhook.acme.com", tags = Map("pipeline" -> "production")))
+    ),
+    license = AcceptedLicense(),
+    skipSchemas = List(
+      SchemaCriterion.parse("iglu:com.acme/skipped1/jsonschema/1-0-0").get,
+      SchemaCriterion.parse("iglu:com.acme/skipped2/jsonschema/1-0-*").get,
+      SchemaCriterion.parse("iglu:com.acme/skipped3/jsonschema/1-*-*").get,
+      SchemaCriterion.parse("iglu:com.acme/skipped4/jsonschema/*-*-*").get
     )
   )
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -66,7 +66,11 @@ object BuildSettings {
 
   lazy val kinesisSettings = appSettings ++ Seq(
     name := "bigquery-loader-kinesis",
-    buildInfoKeys += BuildInfoKey("cloud" -> "AWS")
+    buildInfoKeys += BuildInfoKey("cloud" -> "AWS"),
+    // used in configuration parsing unit tests
+    Test / envVars := Map(
+      "HOSTNAME" -> "test-hostname"
+    )
   )
 
   lazy val addExampleConfToTestCp = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,25 +12,26 @@ object Dependencies {
 
   object V {
     // Scala
-    val catsEffect       = "3.5.0"
-    val catsRetry        = "3.1.0"
-    val http4s           = "0.23.15"
+    val catsEffect       = "3.5.4"
+    val catsRetry        = "3.1.3"
+    val http4s           = "0.23.16"
     val decline          = "2.4.1"
-    val circe            = "0.14.3"
+    val circe            = "0.14.6"
+    val circeExtra       = "0.14.3"
     val betterMonadicFor = "0.3.1"
     val doobie           = "1.0.0-RC4"
 
     // java
-    val slf4j           = "2.0.7"
-    val azureSdk        = "1.9.1"
+    val slf4j           = "2.0.12"
+    val azureSdk        = "1.11.4"
     val sentry          = "6.25.2"
-    val awsSdk2         = "2.20.135"
+    val awsSdk2         = "2.25.16"
     val bigqueryStorage = "2.47.0"
     val bigquery        = "2.34.2"
 
     // Snowplow
-    val streams    = "0.3.0"
-    val igluClient = "3.0.0"
+    val streams    = "0.5.2"
+    val igluClient = "3.1.0"
 
     // tests
     val specs2           = "4.20.0"
@@ -41,7 +42,7 @@ object Dependencies {
   val catsRetry         = "com.github.cb372" %% "cats-retry"           % V.catsRetry
   val blazeClient       = "org.http4s"       %% "http4s-blaze-client"  % V.http4s
   val decline           = "com.monovore"     %% "decline-effect"       % V.decline
-  val circeGenericExtra = "io.circe"         %% "circe-generic-extras" % V.circe
+  val circeGenericExtra = "io.circe"         %% "circe-generic-extras" % V.circeExtra
   val circeLiteral      = "io.circe"         %% "circe-literal"        % V.circe
   val betterMonadicFor  = "com.olegpy"       %% "better-monadic-for"   % V.betterMonadicFor
   val doobie            = "org.tpolecat"     %% "doobie-core"          % V.doobie


### PR DESCRIPTION
common-streams 0.5.2 brings:

* Common `AcceptedLicense` class which can be used to check if user has accepted SLUL.

If user doesn't accept license, error message looks like this:

```
[io-compute-blocker-4] ERROR com.snowplowanalytics.snowplow.bigquery.Run - Cannot resolve config: DecodingFailure at .license: Please accept the terms of the Snowplow Limited Use License Agreement to proceed. See https://docs.snowplow.io/limited-use-license-1.0/ for more information on the license and how to configure this.
```

* Skipping schemas feature for structured events. Filtering criteria are passed as argument to the `NonAtomicFields.resolveTypes` method.
* OAuth2 Event Hubs authentication for Kafka.
* For `Transform.transformrEvent` - `Vector` instead of `List` is returned as a collection storing transformed `NamedValue`s
* Dependencies upgrades