### PR TITLE
Stay healthy if BigQuery table exceeds column limit

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -86,6 +86,14 @@
     "alterTableWait": {
       "delay": "1 second"
     }
+
+    # -- Relevant when the BigQuery table is close to exceeding the limit on max allowed columns in a single table.
+    # -- The loader will ignore a failure to alter the table due to too many columns, and it will continue to run.
+    # -- Some events will inevitably go to the failed events output topic until new columns have been added.
+    # -- This param configures how often the loader will retry to alter the table after an earlier failure.
+    "tooManyColumns": {
+      "delay": "300 seconds"
+    }
   } 
   
   # -- Schemas that won't be loaded to BigQuery. Optional, default value []

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -108,6 +108,14 @@
     "alterTableWait": {
       "delay": "1 second"
     }
+
+    # -- Relevant when the BigQuery table is close to exceeding the limit on max allowed columns in a single table.
+    # -- The loader will ignore a failure to alter the table due to too many columns, and it will continue to run.
+    # -- Some events will inevitably go to the failed events output topic until new columns have been added.
+    # -- This param configures how often the loader will retry to alter the table after an earlier failure.
+    "tooManyColumns": {
+      "delay": "300 seconds"
+    }
   } 
 
   # -- Schemas that won't be loaded to BigQuery. Optional, default value []

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -88,6 +88,14 @@
     "alterTableWait": {
       "delay": "1 second"
     }
+
+    # -- Relevant when the BigQuery table is close to exceeding the limit on max allowed columns in a single table.
+    # -- The loader will ignore a failure to alter the table due to too many columns, and it will continue to run.
+    # -- Some events will inevitably go to the failed events output topic until new columns have been added.
+    # -- This param configures how often the loader will retry to alter the table after an earlier failure.
+    "tooManyColumns": {
+      "delay": "300 seconds"
+    }
   } 
 
   # -- Schemas that won't be loaded to BigQuery. Optional, default value []

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -35,6 +35,9 @@
     "alterTableWait": {
       "delay": "1 second"
     }
+    "tooManyColumns": {
+      "delay": "300 seconds"
+    }
   }
   
   "skipSchemas": []

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
@@ -86,11 +86,13 @@ object Config {
   case class SetupErrorRetries(delay: FiniteDuration)
   case class AlterTableWaitRetries(delay: FiniteDuration)
   case class TransientErrorRetries(delay: FiniteDuration, attempts: Int)
+  case class TooManyColumnsRetries(delay: FiniteDuration)
 
   case class Retries(
     setupErrors: SetupErrorRetries,
     transientErrors: TransientErrorRetries,
-    alterTableWait: AlterTableWaitRetries
+    alterTableWait: AlterTableWaitRetries,
+    tooManyColumns: TooManyColumnsRetries
   )
 
   implicit def decoder[Source: Decoder, Sink: Decoder]: Decoder[Config[Source, Sink]] = {
@@ -119,6 +121,7 @@ object Config {
     implicit val setupRetries       = deriveConfiguredDecoder[SetupErrorRetries]
     implicit val alterTableRetries  = deriveConfiguredDecoder[AlterTableWaitRetries]
     implicit val transientRetries   = deriveConfiguredDecoder[TransientErrorRetries]
+    implicit val tooManyColsRetries = deriveConfiguredDecoder[TooManyColumnsRetries]
     implicit val retriesDecoder     = deriveConfiguredDecoder[Retries]
 
     // TODO add bigquery docs

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQuerySchemaUtils.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQuerySchemaUtils.scala
@@ -16,8 +16,8 @@ import scala.jdk.CollectionConverters._
 
 object BigQuerySchemaUtils {
 
-  def alterTableRequired(tableDescriptor: Descriptors.Descriptor, ddlFields: Seq[Field]): Boolean =
-    ddlFields.exists { field =>
+  def alterTableRequired(tableDescriptor: Descriptors.Descriptor, ddlFields: Seq[Field]): Seq[Field] =
+    ddlFields.filter { field =>
       Option(tableDescriptor.findFieldByName(field.name)) match {
         case Some(fieldDescriptor) =>
           val nullableMismatch = fieldDescriptor.isRequired && field.nullability.nullable
@@ -32,7 +32,7 @@ object BigQuerySchemaUtils {
       case Descriptors.FieldDescriptor.Type.MESSAGE =>
         ddlField.fieldType match {
           case Type.Struct(nestedFields) =>
-            alterTableRequired(tableField.getMessageType, nestedFields)
+            alterTableRequired(tableField.getMessageType, nestedFields).nonEmpty
           case _ =>
             false
         }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQueryUtils.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQueryUtils.scala
@@ -35,13 +35,18 @@ object BigQueryUtils {
   def streamIdOf(config: Config.BigQuery): String =
     tableIdOf(config).getIAMResourceName + "/streams/_default"
 
-  object BQExceptionWithLowerCaseReason {
-    def unapply(bqe: BigQueryException): Option[(String)] =
-      Option(bqe.getError()) match {
-        case Some(bqError) =>
-          Some(bqError.getReason.toLowerCase)
-        case None =>
-          None
-      }
+  implicit class BQExceptionSyntax(val bqe: BigQueryException) extends AnyVal {
+    def lowerCaseReason: String =
+      Option(bqe.getError())
+        .flatMap(e => Option(e.getReason))
+        .map(_.toLowerCase)
+        .getOrElse("")
+
+    def lowerCaseMessage: String =
+      Option(bqe.getError())
+        .flatMap(e => Option(e.getMessage))
+        .map(_.toLowerCase)
+        .getOrElse("")
+
   }
 }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/Processing.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/Processing.scala
@@ -297,8 +297,9 @@ object Processing {
           val fields = batch.entities.fields.flatMap { tte =>
             tte.mergedField :: tte.recoveries.map(_._2)
           }
-          if (BigQuerySchemaUtils.alterTableRequired(descriptor, fields)) {
-            env.tableManager.addColumns(fields) *> env.writer.closed.use_
+          val fieldsToAdd = BigQuerySchemaUtils.alterTableRequired(descriptor, fields)
+          if (fieldsToAdd.nonEmpty) {
+            env.tableManager.addColumns(fieldsToAdd.toVector) *> env.writer.closed.use_
           } else {
             Sync[F].unit
           }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/TableManager.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/TableManager.scala
@@ -10,7 +10,8 @@ package com.snowplowanalytics.snowplow.bigquery.processing
 
 import cats.Show
 import cats.implicits._
-import cats.effect.{Async, Sync}
+import cats.effect.implicits._
+import cats.effect.{Async, Ref, Sync}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import com.google.cloud.bigquery.{
@@ -25,10 +26,12 @@ import com.google.cloud.bigquery.{
   TimePartitioning
 }
 import com.google.auth.Credentials
+import com.google.cloud.bigquery.BigQueryException
 
 import com.snowplowanalytics.iglu.schemaddl.parquet.Field
 import com.snowplowanalytics.snowplow.loaders.transform.AtomicFields
 import com.snowplowanalytics.snowplow.bigquery.{Alert, AppHealth, Config, Monitoring}
+import com.snowplowanalytics.snowplow.bigquery.processing.BigQueryUtils.BQExceptionSyntax
 
 import scala.jdk.CollectionConverters._
 
@@ -44,73 +47,101 @@ object TableManager {
 
   private implicit def logger[F[_]: Sync] = Slf4jLogger.getLogger[F]
 
+  trait WithHandledErrors[F[_]] extends TableManager[F]
+
   def make[F[_]: Async](
     config: Config.BigQuery,
-    retries: Config.Retries,
-    credentials: Credentials,
-    appHealth: AppHealth[F],
-    monitoring: Monitoring[F]
+    credentials: Credentials
   ): F[TableManager[F]] =
     for {
       client <- Sync[F].delay(BigQueryOptions.newBuilder.setCredentials(credentials).build.getService)
-    } yield impl(config, retries, client, appHealth, monitoring)
+    } yield impl(config, client)
+
+  def withHandledErrors[F[_]: Async](
+    underlying: TableManager[F],
+    retries: Config.Retries,
+    appHealth: AppHealth[F],
+    monitoring: Monitoring[F]
+  ): F[WithHandledErrors[F]] =
+    for {
+      addingColumnsEnabled <- Ref[F].of[Boolean](true)
+    } yield new WithHandledErrors[F] {
+      def addColumns(columns: Vector[Field]): F[Unit] =
+        addingColumnsEnabled.get.flatMap {
+          case true =>
+            BigQueryRetrying
+              .withRetries(appHealth, retries, monitoring, Alert.FailedToAddColumns(columns.map(_.name), _)) {
+                Logger[F].info(s"Altering table to add columns [${showColumns(columns)}]") *>
+                  underlying
+                    .addColumns(columns)
+                    .recoverWith(handleTooManyColumns(retries, monitoring, addingColumnsEnabled, columns))
+                    .onError(logOnRaceCondition)
+              }
+          case false =>
+            Async[F].unit
+        }
+
+      def createTable: F[Unit] =
+        BigQueryRetrying.withRetries(appHealth, retries, monitoring, Alert.FailedToCreateEventsTable(_)) {
+          underlying.createTable
+            .recoverWith {
+              case bqe: BigQueryException if bqe.lowerCaseReason === "duplicate" =>
+                // Table already exists
+                Logger[F].info(s"Ignoring error when creating table: ${bqe.getMessage}")
+              case bqe: BigQueryException if bqe.lowerCaseReason === "accessdenied" =>
+                Logger[F].info(s"Access denied when trying to create table. Will ignore error and assume table already exists.")
+            }
+        }
+    }
 
   private def impl[F[_]: Async](
     config: Config.BigQuery,
-    retries: Config.Retries,
-    client: BigQuery,
-    appHealth: AppHealth[F],
-    monitoring: Monitoring[F]
+    client: BigQuery
   ): TableManager[F] = new TableManager[F] {
 
     def addColumns(columns: Vector[Field]): F[Unit] =
-      BigQueryRetrying.withRetries(appHealth, retries, monitoring, Alert.FailedToAddColumns(columns.map(_.name), _)) {
-        Logger[F].info(s"Altering table to add columns [${showColumns(columns)}]") *>
-          addColumnsImpl(config, client, columns)
-      }
+      for {
+        table <- Sync[F].blocking(client.getTable(config.dataset, config.table))
+        schema <- Sync[F].pure(table.getDefinition[TableDefinition].getSchema)
+        fields <- Sync[F].pure(schema.getFields)
+        fields <- Sync[F].pure(BigQuerySchemaUtils.mergeInColumns(fields, columns))
+        schema <- Sync[F].pure(Schema.of(fields))
+        table <- Sync[F].pure(setTableSchema(table, schema))
+        _ <- Sync[F].blocking(table.update())
+      } yield ()
 
-    def createTable: F[Unit] =
-      BigQueryRetrying.withRetries(appHealth, retries, monitoring, Alert.FailedToCreateEventsTable(_)) {
-        val tableInfo = atomicTableInfo(config)
-        Logger[F].info(show"Creating table $tableInfo") *>
-          Sync[F]
-            .blocking(client.create(tableInfo))
-            .void
-            .recoverWith {
-              case bqe @ BigQueryUtils.BQExceptionWithLowerCaseReason("duplicate") =>
-                // Table already exists
-                Logger[F].info(s"Ignoring error when creating table: ${bqe.getMessage}")
-              case BigQueryUtils.BQExceptionWithLowerCaseReason("accessdenied") =>
-                Logger[F].info(s"Access denied when trying to create table. Will ignore error and assume table already exists.")
-            }
-      }
+    def createTable: F[Unit] = {
+      val tableInfo = atomicTableInfo(config)
+      Logger[F].info(show"Creating table $tableInfo") *>
+        Sync[F]
+          .blocking(client.create(tableInfo))
+          .void
+    }
   }
-
-  private def addColumnsImpl[F[_]: Sync](
-    config: Config.BigQuery,
-    client: BigQuery,
-    columns: Vector[Field]
-  ): F[Unit] =
-    for {
-      table <- Sync[F].blocking(client.getTable(config.dataset, config.table))
-      schema <- Sync[F].pure(table.getDefinition[TableDefinition].getSchema)
-      fields <- Sync[F].pure(schema.getFields)
-      fields <- Sync[F].pure(BigQuerySchemaUtils.mergeInColumns(fields, columns))
-      schema <- Sync[F].pure(Schema.of(fields))
-      table <- Sync[F].pure(setTableSchema(table, schema))
-      _ <- Sync[F]
-             .blocking(table.update())
-             .void
-             .onError(logOnRaceCondition)
-    } yield ()
 
   private def setTableSchema(table: Table, schema: Schema): Table =
     table.toBuilder().setDefinition(StandardTableDefinition.of(schema)).build()
 
   private def logOnRaceCondition[F[_]: Sync]: PartialFunction[Throwable, F[Unit]] = {
-    case BigQueryUtils.BQExceptionWithLowerCaseReason("invalid") =>
+    case bqe: BigQueryException if bqe.lowerCaseReason === "invalid" =>
       Logger[F].warn(s"Caught known exception which probably means another loader has already altered the table.")
     // Don't do anything else; the BigQueryRetrying will handle retries and logging the exception.
+  }
+
+  private def handleTooManyColumns[F[_]: Async](
+    retries: Config.Retries,
+    monitoring: Monitoring[F],
+    addingColumnsEnabled: Ref[F, Boolean],
+    columns: Vector[Field]
+  ): PartialFunction[Throwable, F[Unit]] = {
+    case bqe: BigQueryException if bqe.lowerCaseReason === "invalid" && bqe.lowerCaseMessage.startsWith("too many columns") =>
+      val enableAfterDelay = Async[F].sleep(retries.tooManyColumns.delay) *> addingColumnsEnabled.set(true)
+      for {
+        _ <- Logger[F].error(bqe)(s"Could not alter table schema because of too many columns")
+        _ <- monitoring.alert(Alert.FailedToAddColumns(columns.map(_.name), bqe))
+        _ <- addingColumnsEnabled.set(false)
+        _ <- enableAfterDelay.start
+      } yield ()
   }
 
   private def showColumns(columns: Vector[Field]): String =

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/AlertSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/AlertSpec.scala
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2013-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd., under the terms of the Snowplow
+ * Limited Use License Agreement, Version 1.0 located at
+ * https://docs.snowplow.io/limited-use-license-1.0 BY INSTALLING, DOWNLOADING, ACCESSING, USING OR
+ * DISTRIBUTING ANY PORTION OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+package com.snowplowanalytics.snowplow.bigquery
+
+import org.specs2.Specification
+
+class AlertSpec extends Specification {
+
+  def is = s2"""
+  An Alert should:
+    Generate a message describing an exception and any nested cause $e1
+    Collapse messages if a cause's message contains the parent exception's message $e2
+    Collapse messages if a parent exception's message contains the cause's message $e3
+  """
+
+  def e1 = {
+    val e1 = new RuntimeException("original cause")
+    val e2 = new RuntimeException("middle cause", e1)
+    val e3 = new RuntimeException("final error", e2)
+
+    val alert = Alert.FailedToCreateEventsTable(e3)
+
+    val expected = "Failed to create events table: final error: middle cause: original cause"
+
+    Alert.getMessage(alert) must beEqualTo(expected)
+  }
+
+  def e2 = {
+    val e1 = new RuntimeException("This happened: original cause")
+    val e2 = new RuntimeException("original cause", e1)
+
+    val alert = Alert.FailedToCreateEventsTable(e2)
+
+    val expected = "Failed to create events table: This happened: original cause"
+
+    Alert.getMessage(alert) must beEqualTo(expected)
+  }
+
+  def e3 = {
+    val e1 = new RuntimeException("original cause")
+    val e2 = new RuntimeException("This happened: original cause", e1)
+
+    val alert = Alert.FailedToCreateEventsTable(e2)
+
+    val expected = "Failed to create events table: This happened: original cause"
+
+    Alert.getMessage(alert) must beEqualTo(expected)
+  }
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/TableManagerSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/TableManagerSpec.scala
@@ -1,0 +1,407 @@
+/**
+ * Copyright (c) 2013-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd., under the terms of the Snowplow
+ * Limited Use License Agreement, Version 1.0 located at
+ * https://docs.snowplow.io/limited-use-license-1.0 BY INSTALLING, DOWNLOADING, ACCESSING, USING OR
+ * DISTRIBUTING ANY PORTION OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+package com.snowplowanalytics.snowplow.bigquery.processing
+
+import cats.implicits._
+import cats.effect.{IO, Ref}
+import org.specs2.Specification
+import cats.effect.testing.specs2.CatsEffect
+import cats.effect.testkit.TestControl
+import com.google.api.gax.rpc.PermissionDeniedException
+import com.google.api.gax.grpc.GrpcStatusCode
+import io.grpc.Status
+import com.google.cloud.bigquery.{BigQueryError, BigQueryException}
+
+import scala.concurrent.duration.{DurationLong, FiniteDuration}
+
+import com.snowplowanalytics.iglu.schemaddl.parquet.{Field, Type}
+import com.snowplowanalytics.snowplow.bigquery.{Alert, AppHealth, Config, Monitoring}
+import com.snowplowanalytics.snowplow.runtime.HealthProbe
+import com.snowplowanalytics.snowplow.bigquery.AppHealth.Service
+import com.snowplowanalytics.snowplow.sources.{EventProcessingConfig, EventProcessor, SourceAndAck}
+
+class TableManagerSpec extends Specification with CatsEffect {
+  import TableManagerSpec._
+
+  def is = s2"""
+  The table manager
+    Add columns when told to $e1
+    Retry adding columns and send alerts when there is a setup exceptionr $e2
+    Retry adding columns if there is a transient exception, with limited number of attempts and no monitoring alerts $e3
+    Become healthy after recovering from an earlier setup error $e4
+    Become healthy after recovering from an earlier transient error $e5
+    Disable future attempts to add columns if the table has too many columns $e6
+    Eventually re-enable future attempts to add columns if the table has too many columns $e7
+  """
+
+  def e1 = control().flatMap { c =>
+    val testFields1 = Vector(
+      Field("f1", Type.String, Type.Nullability.Nullable, Set("f1")),
+      Field("f2", Type.Integer, Type.Nullability.Required, Set("f2"))
+    )
+
+    val testFields2 = Vector(
+      Field("f3", Type.String, Type.Nullability.Nullable, Set("f3")),
+      Field("f4", Type.Integer, Type.Nullability.Required, Set("f4"))
+    )
+
+    val io = for {
+      tableManager <- TableManager.withHandledErrors(c.tableManager, retriesConfig, c.appHealth, c.monitoring)
+      _ <- tableManager.addColumns(testFields1)
+      _ <- tableManager.addColumns(testFields2)
+    } yield ()
+
+    val expected = Vector(
+      Action.AddColumnsAttempted(testFields1),
+      Action.AddColumnsAttempted(testFields2)
+    )
+
+    for {
+      _ <- io
+      state <- c.state.get
+      health <- c.appHealth.status
+    } yield List(
+      state should beEqualTo(expected),
+      health should beHealthy
+    ).reduce(_ and _)
+  }
+
+  def e2 = {
+    val mocks = List.fill(100)(Response.ExceptionThrown(testSetupError))
+
+    control(Mocks(addColumnsResults = mocks)).flatMap { c =>
+      val testFields = Vector(
+        Field("f1", Type.String, Type.Nullability.Nullable, Set("f1")),
+        Field("f2", Type.Integer, Type.Nullability.Required, Set("f2"))
+      )
+
+      val io = for {
+        tableManager <- TableManager.withHandledErrors(c.tableManager, retriesConfig, c.appHealth, c.monitoring)
+        _ <- tableManager.addColumns(testFields)
+      } yield ()
+
+      val expected = Vector(
+        Action.AddColumnsAttempted(testFields),
+        Action.SentAlert(0L),
+        Action.AddColumnsAttempted(testFields),
+        Action.SentAlert(30L),
+        Action.AddColumnsAttempted(testFields),
+        Action.SentAlert(90L),
+        Action.AddColumnsAttempted(testFields),
+        Action.SentAlert(210L)
+      )
+
+      val test = for {
+        fiber <- io.start
+        _ <- IO.sleep(4.minutes)
+        _ <- fiber.cancel
+        state <- c.state.get
+        health <- c.appHealth.status
+      } yield List(
+        state should beEqualTo(expected),
+        health should beUnhealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  def e3 = {
+    val mocks = List.fill(100)(Response.ExceptionThrown(new RuntimeException("Boom!")))
+    control(Mocks(addColumnsResults = mocks)).flatMap { c =>
+      val testFields = Vector(
+        Field("f1", Type.String, Type.Nullability.Nullable, Set("f1")),
+        Field("f2", Type.Integer, Type.Nullability.Required, Set("f2"))
+      )
+
+      val io = for {
+        tableManager <- TableManager.withHandledErrors(c.tableManager, retriesConfig, c.appHealth, c.monitoring)
+        _ <- tableManager.addColumns(testFields)
+      } yield ()
+
+      val expected = Vector(
+        Action.AddColumnsAttempted(testFields),
+        Action.AddColumnsAttempted(testFields),
+        Action.AddColumnsAttempted(testFields),
+        Action.AddColumnsAttempted(testFields),
+        Action.AddColumnsAttempted(testFields)
+      )
+
+      val test = for {
+        _ <- io.voidError
+        state <- c.state.get
+        health <- c.appHealth.status
+      } yield List(
+        state should beEqualTo(expected),
+        health should beUnhealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  def e4 = {
+    val mocks = List(Response.ExceptionThrown(testSetupError))
+
+    control(Mocks(addColumnsResults = mocks)).flatMap { c =>
+      val testFields = Vector(
+        Field("f1", Type.String, Type.Nullability.Nullable, Set("f1")),
+        Field("f2", Type.Integer, Type.Nullability.Required, Set("f2"))
+      )
+
+      val io = for {
+        tableManager <- TableManager.withHandledErrors(c.tableManager, retriesConfig, c.appHealth, c.monitoring)
+        _ <- tableManager.addColumns(testFields)
+      } yield ()
+
+      val expected = Vector(
+        Action.AddColumnsAttempted(testFields),
+        Action.SentAlert(0L),
+        Action.AddColumnsAttempted(testFields)
+      )
+
+      val test = for {
+        _ <- io.voidError
+        state <- c.state.get
+        health <- c.appHealth.status
+      } yield List(
+        state should beEqualTo(expected),
+        health should beHealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  def e5 = {
+    val mocks = List(Response.ExceptionThrown(new RuntimeException("boom!")))
+
+    control(Mocks(addColumnsResults = mocks)).flatMap { c =>
+      val testFields = Vector(
+        Field("f1", Type.String, Type.Nullability.Nullable, Set("f1")),
+        Field("f2", Type.Integer, Type.Nullability.Required, Set("f2"))
+      )
+
+      val io = for {
+        tableManager <- TableManager.withHandledErrors(c.tableManager, retriesConfig, c.appHealth, c.monitoring)
+        _ <- tableManager.addColumns(testFields)
+      } yield ()
+
+      val expected = Vector(
+        Action.AddColumnsAttempted(testFields),
+        Action.AddColumnsAttempted(testFields)
+      )
+
+      val test = for {
+        _ <- io.voidError
+        state <- c.state.get
+        health <- c.appHealth.status
+      } yield List(
+        state should beEqualTo(expected),
+        health should beHealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  def e6 = {
+    val error     = new BigQueryError("invalid", "global", "Too many columns (10067) in schema. Only 10000 columns are allowed.")
+    val exception = new BigQueryException(400, error.getMessage, error)
+    val mocks     = List(Response.ExceptionThrown(exception))
+    control(Mocks(addColumnsResults = mocks)).flatMap { c =>
+      val testFields1 = Vector(
+        Field("f1", Type.String, Type.Nullability.Nullable, Set("f1")),
+        Field("f2", Type.Integer, Type.Nullability.Required, Set("f2"))
+      )
+
+      val testFields2 = Vector(
+        Field("f3", Type.String, Type.Nullability.Nullable, Set("f3")),
+        Field("f4", Type.Integer, Type.Nullability.Required, Set("f4"))
+      )
+
+      val io = for {
+        tableManager <- TableManager.withHandledErrors(c.tableManager, retriesConfig, c.appHealth, c.monitoring)
+        _ <- tableManager.addColumns(testFields1)
+        _ <- IO.sleep(10.seconds)
+        _ <- tableManager.addColumns(testFields2)
+      } yield ()
+
+      val expected = Vector(
+        Action.AddColumnsAttempted(testFields1),
+        Action.SentAlert(0L)
+      )
+
+      val test = for {
+        _ <- io
+        state <- c.state.get
+        health <- c.appHealth.status
+      } yield List(
+        state should beEqualTo(expected),
+        health should beHealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  def e7 = {
+    val error     = new BigQueryError("invalid", "global", "Too many columns (10067) in schema. Only 10000 columns are allowed.")
+    val exception = new BigQueryException(400, error.getMessage, error)
+    val mocks     = List(Response.ExceptionThrown(exception))
+    control(Mocks(addColumnsResults = mocks)).flatMap { c =>
+      val testFields1 = Vector(
+        Field("f1", Type.String, Type.Nullability.Nullable, Set("f1")),
+        Field("f2", Type.Integer, Type.Nullability.Required, Set("f2"))
+      )
+
+      val testFields2 = Vector(
+        Field("f3", Type.String, Type.Nullability.Nullable, Set("f3")),
+        Field("f4", Type.Integer, Type.Nullability.Required, Set("f4"))
+      )
+
+      val io = for {
+        tableManager <- TableManager.withHandledErrors(c.tableManager, retriesConfig, c.appHealth, c.monitoring)
+        _ <- tableManager.addColumns(testFields1)
+        _ <- IO.sleep(310.seconds)
+        _ <- tableManager.addColumns(testFields2)
+      } yield ()
+
+      val expected = Vector(
+        Action.AddColumnsAttempted(testFields1),
+        Action.SentAlert(0L),
+        Action.AddColumnsAttempted(testFields2)
+      )
+
+      val test = for {
+        _ <- io
+        state <- c.state.get
+        health <- c.appHealth.status
+      } yield List(
+        state should beEqualTo(expected),
+        health should beHealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  /** Convenience matchers for health probe * */
+
+  def beHealthy: org.specs2.matcher.Matcher[HealthProbe.Status] = { (status: HealthProbe.Status) =>
+    val result = status match {
+      case HealthProbe.Healthy      => true
+      case HealthProbe.Unhealthy(_) => false
+    }
+    (result, s"$status is not healthy")
+  }
+
+  def beUnhealthy: org.specs2.matcher.Matcher[HealthProbe.Status] = { (status: HealthProbe.Status) =>
+    val result = status match {
+      case HealthProbe.Healthy      => false
+      case HealthProbe.Unhealthy(_) => true
+    }
+    (result, s"$status is not unhealthy")
+  }
+}
+
+object TableManagerSpec {
+
+  sealed trait Action
+
+  object Action {
+    case class AddColumnsAttempted(columns: Vector[Field]) extends Action
+    case class SentAlert(timeSentSeconds: Long) extends Action
+  }
+
+  sealed trait Response
+  object Response {
+    case object Success extends Response
+    final case class ExceptionThrown(value: Throwable) extends Response
+  }
+
+  case class Mocks(addColumnsResults: List[Response])
+
+  case class Control(
+    state: Ref[IO, Vector[Action]],
+    tableManager: TableManager[IO],
+    appHealth: AppHealth[IO],
+    monitoring: Monitoring[IO]
+  )
+
+  def retriesConfig = Config.Retries(
+    Config.SetupErrorRetries(30.seconds),
+    Config.TransientErrorRetries(1.second, 5),
+    Config.AlterTableWaitRetries(1.second),
+    Config.TooManyColumnsRetries(300.seconds)
+  )
+
+  def control(mocks: Mocks = Mocks(Nil)): IO[Control] =
+    for {
+      state <- Ref[IO].of(Vector.empty[Action])
+      appHealth <- testAppHealth()
+      tableManager <- testTableManager(state, mocks.addColumnsResults)
+    } yield Control(state, tableManager, appHealth, testMonitoring(state))
+
+  private def testAppHealth(): IO[AppHealth[IO]] = {
+    val everythingHealthy: Map[AppHealth.Service, Boolean] = Map(Service.BigQueryClient -> true, Service.BadSink -> true)
+    val healthySource = new SourceAndAck[IO] {
+      override def stream(config: EventProcessingConfig, processor: EventProcessor[IO]): fs2.Stream[IO, Nothing] =
+        fs2.Stream.empty
+
+      override def isHealthy(maxAllowedProcessingLatency: FiniteDuration): IO[SourceAndAck.HealthStatus] =
+        IO(SourceAndAck.Healthy)
+    }
+    AppHealth.init(10.seconds, healthySource, everythingHealthy)
+  }
+
+  private def testTableManager(state: Ref[IO, Vector[Action]], mocks: List[Response]): IO[TableManager[IO]] =
+    for {
+      mocksRef <- Ref[IO].of(mocks)
+    } yield new TableManager[IO] {
+      def addColumns(columns: Vector[Field]): IO[Unit] =
+        for {
+          response <- mocksRef.modify {
+                        case head :: tail => (tail, head)
+                        case Nil          => (Nil, Response.Success)
+                      }
+          _ <- state.update(_ :+ Action.AddColumnsAttempted(columns))
+          result <- response match {
+                      case Response.Success =>
+                        IO.unit
+                      case Response.ExceptionThrown(ex) =>
+                        IO.raiseError(ex).adaptError { t =>
+                          t.setStackTrace(Array()) // don't clutter our test logs
+                          t
+                        }
+                    }
+        } yield result
+
+      def createTable: IO[Unit] =
+        IO.unit
+
+    }
+
+  private def testMonitoring(state: Ref[IO, Vector[Action]]): Monitoring[IO] = new Monitoring[IO] {
+    def alert(message: Alert): IO[Unit] =
+      for {
+        now <- IO.realTime
+        _ <- state.update(_ :+ Action.SentAlert(now.toSeconds))
+      } yield ()
+  }
+
+  def testSetupError: Throwable = {
+    val inner = new RuntimeException("go away")
+    inner.setStackTrace(Array()) // don't clutter our test logs
+    val t = new PermissionDeniedException(inner, GrpcStatusCode.of(Status.Code.PERMISSION_DENIED), false)
+    t.setStackTrace(Array()) // don't clutter our test logs
+    t
+  }
+
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/WriterProviderSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/WriterProviderSpec.scala
@@ -318,7 +318,8 @@ object WriterProviderSpec {
   def retriesConfig = Config.Retries(
     Config.SetupErrorRetries(30.seconds),
     Config.TransientErrorRetries(1.second, 5),
-    Config.AlterTableWaitRetries(1.second)
+    Config.AlterTableWaitRetries(1.second),
+    Config.TooManyColumnsRetries(300.seconds)
   )
 
   def control: IO[Control] =

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
@@ -102,7 +102,8 @@ object KafkaConfigSpec {
     retries = Config.Retries(
       setupErrors     = Config.SetupErrorRetries(delay = 30.seconds),
       transientErrors = Config.TransientErrorRetries(delay = 1.second, attempts = 5),
-      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second)
+      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second),
+      tooManyColumns  = Config.TooManyColumnsRetries(delay = 300.seconds)
     ),
     telemetry = Telemetry.Config(
       disable         = false,
@@ -170,7 +171,8 @@ object KafkaConfigSpec {
     retries = Config.Retries(
       setupErrors     = Config.SetupErrorRetries(delay = 30.seconds),
       transientErrors = Config.TransientErrorRetries(delay = 1.second, attempts = 5),
-      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second)
+      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second),
+      tooManyColumns  = Config.TooManyColumnsRetries(delay = 300.seconds)
     ),
     telemetry = Telemetry.Config(
       disable         = false,

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
@@ -100,7 +100,8 @@ object KinesisConfigSpec {
     retries = Config.Retries(
       setupErrors     = Config.SetupErrorRetries(delay = 30.seconds),
       transientErrors = Config.TransientErrorRetries(delay = 1.second, attempts = 5),
-      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second)
+      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second),
+      tooManyColumns  = Config.TooManyColumnsRetries(delay = 300.seconds)
     ),
     telemetry = Telemetry.Config(
       disable         = false,
@@ -165,7 +166,8 @@ object KinesisConfigSpec {
     retries = Config.Retries(
       setupErrors     = Config.SetupErrorRetries(delay = 30.seconds),
       transientErrors = Config.TransientErrorRetries(delay = 1.second, attempts = 5),
-      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second)
+      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second),
+      tooManyColumns  = Config.TooManyColumnsRetries(delay = 300.seconds)
     ),
     telemetry = Telemetry.Config(
       disable         = false,

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
@@ -97,7 +97,8 @@ object PubsubConfigSpec {
     retries = Config.Retries(
       setupErrors     = Config.SetupErrorRetries(delay = 30.seconds),
       transientErrors = Config.TransientErrorRetries(delay = 1.second, attempts = 5),
-      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second)
+      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second),
+      tooManyColumns  = Config.TooManyColumnsRetries(delay = 300.seconds)
     ),
     telemetry = Telemetry.Config(
       disable         = false,
@@ -158,7 +159,8 @@ object PubsubConfigSpec {
     retries = Config.Retries(
       setupErrors     = Config.SetupErrorRetries(delay = 30.seconds),
       transientErrors = Config.TransientErrorRetries(delay = 1.second, attempts = 5),
-      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second)
+      alterTableWait  = Config.AlterTableWaitRetries(delay = 1.second),
+      tooManyColumns  = Config.TooManyColumnsRetries(delay = 300.seconds)
     ),
     telemetry = Telemetry.Config(
       disable         = false,


### PR DESCRIPTION
With BigQuery Loader v1, we have previously hit problems when the number of columns in the table gets close to 10000.  This is much less likely with Loader v2, but even so we should handle that situation elegantly.

After this commit, we will catch and handle the known exception when the table exceeds the maximum number of columns.  After receiving that exception once, the loader should stay healthy and not make any further attempt to alter the table.  Any event should go to the bad topic, if it cannot fit into the un-altered table.