### PR TITLE
Feature flag to support the legacy column style

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -104,6 +104,10 @@
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
 
+  # -- Whether to turn on the legacy column style used by the v1 BigQuery loader
+  # -- In this mode, there is a column per _minor_ version of each schema.
+  "legacyColumns": false
+
   "monitoring": {
     "metrics": {
 

--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -104,9 +104,12 @@
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
 
-  # -- Whether to turn on the legacy column style used by the v1 BigQuery loader
-  # -- In this mode, there is a column per _minor_ version of each schema.
-  "legacyColumns": false
+  # -- Schemas for which to use the legacy column style used by the v1 BigQuery loader
+  # -- For these columns, there is a column per _minor_ version of each schema.
+  "legacyColumns": [
+    "iglu:com.acme/legacy/jsonschema/1-*-*"
+    "iglu:com.acme/legacy/jsonschema/2-*-*"
+  ]
 
   "monitoring": {
     "metrics": {

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -125,6 +125,10 @@
     "iglu:com.acme/skipped3/jsonschema/1-*-*",
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
+
+  # -- Whether to turn on the legacy column style used by the v1 BigQuery loader
+  # -- In this mode, there is a column per _minor_ version of each schema.
+  "legacyColumns": false
   
   "monitoring": {
     "metrics": {

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -126,9 +126,12 @@
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
 
-  # -- Whether to turn on the legacy column style used by the v1 BigQuery loader
-  # -- In this mode, there is a column per _minor_ version of each schema.
-  "legacyColumns": false
+  # -- Schemas for which to use the legacy column style used by the v1 BigQuery loader
+  # -- For these columns, there is a column per _minor_ version of each schema.
+  "legacyColumns": [
+    "iglu:com.acme/legacy/jsonschema/1-*-*"
+    "iglu:com.acme/legacy/jsonschema/2-*-*"
+  ]
   
   "monitoring": {
     "metrics": {

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -106,9 +106,12 @@
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
 
-  # -- Whether to turn on the legacy column style used by the v1 BigQuery loader
-  # -- In this mode, there is a column per _minor_ version of each schema.
-  "legacyColumns": false
+  # -- Schemas for which to use the legacy column style used by the v1 BigQuery loader
+  # -- For these columns, there is a column per _minor_ version of each schema.
+  "legacyColumns": [
+    "iglu:com.acme/legacy/jsonschema/1-*-*"
+    "iglu:com.acme/legacy/jsonschema/2-*-*"
+  ]
   
   "monitoring": {
     "metrics": {

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -105,6 +105,10 @@
     "iglu:com.acme/skipped3/jsonschema/1-*-*",
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
+
+  # -- Whether to turn on the legacy column style used by the v1 BigQuery loader
+  # -- In this mode, there is a column per _minor_ version of each schema.
+  "legacyColumns": false
   
   "monitoring": {
     "metrics": {

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -41,7 +41,7 @@
   }
   
   "skipSchemas": []
-  "legacyColumns": false
+  "legacyColumns": []
 
   "monitoring": {
     "metrics": {

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -41,6 +41,7 @@
   }
   
   "skipSchemas": []
+  "legacyColumns": false
 
   "monitoring": {
     "metrics": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
@@ -33,7 +33,7 @@ case class Config[+Source, +Sink](
   monitoring: Config.Monitoring,
   license: AcceptedLicense,
   skipSchemas: List[SchemaCriterion],
-  legacyColumns: Boolean
+  legacyColumns: List[SchemaCriterion]
 )
 
 object Config {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
@@ -32,7 +32,8 @@ case class Config[+Source, +Sink](
   telemetry: Telemetry.Config,
   monitoring: Config.Monitoring,
   license: AcceptedLicense,
-  skipSchemas: List[SchemaCriterion]
+  skipSchemas: List[SchemaCriterion],
+  legacyColumns: Boolean
 )
 
 object Config {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
@@ -35,7 +35,8 @@ case class Environment[F[_]](
   alterTableWaitPolicy: RetryPolicy[F],
   batching: Config.Batching,
   badRowMaxSize: Int,
-  schemasToSkip: List[SchemaCriterion]
+  schemasToSkip: List[SchemaCriterion],
+  legacyColumns: Boolean
 )
 
 object Environment {
@@ -79,7 +80,8 @@ object Environment {
       alterTableWaitPolicy = BigQueryRetrying.policyForAlterTableWait(config.main.retries),
       batching             = config.main.batching,
       badRowMaxSize        = config.main.output.bad.maxRecordSize,
-      schemasToSkip        = config.main.skipSchemas
+      schemasToSkip        = config.main.skipSchemas,
+      legacyColumns        = config.main.legacyColumns
     )
 
   private def enableSentry[F[_]: Sync](appInfo: AppInfo, config: Option[Config.Sentry]): Resource[F, Unit] =

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
@@ -36,7 +36,7 @@ case class Environment[F[_]](
   batching: Config.Batching,
   badRowMaxSize: Int,
   schemasToSkip: List[SchemaCriterion],
-  legacyColumns: Boolean
+  legacyColumns: List[SchemaCriterion]
 )
 
 object Environment {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQueryCaster.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQueryCaster.scala
@@ -20,7 +20,7 @@ import com.snowplowanalytics.iglu.schemaddl.parquet.Caster
 import scala.jdk.CollectionConverters._
 
 /** Converts schema-ddl values into objects which are compatible with the BigQuery sdk */
-private[processing] object BigQueryCaster extends Caster[AnyRef] {
+private[processing] trait BigQueryCaster extends Caster[AnyRef] {
 
   override def nullValue: Null                             = null
   override def jsonValue(v: Json): String                  = v.noSpaces
@@ -46,3 +46,5 @@ private[processing] object BigQueryCaster extends Caster[AnyRef] {
     new JSONObject(map)
   }
 }
+
+private[processing] object BigQueryCaster extends BigQueryCaster

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumns.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumns.scala
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) 2013-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd., under the terms of the Snowplow
+ * Limited Use License Agreement, Version 1.0 located at
+ * https://docs.snowplow.io/limited-use-license-1.0 BY INSTALLING, DOWNLOADING, ACCESSING, USING OR
+ * DISTRIBUTING ANY PORTION OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+package com.snowplowanalytics.snowplow.bigquery.processing
+
+import cats.Eq
+import cats.data.{EitherT, NonEmptyList, Validated, ValidatedNel}
+import cats.implicits._
+import cats.effect.Sync
+import io.circe.Json
+
+import com.snowplowanalytics.iglu.client.{ClientError, Resolver}
+import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.iglu.schemaddl.bigquery.{Field => LegacyField, Mode => LegacyMode, Type => LegacyType}
+import com.snowplowanalytics.iglu.schemaddl.parquet.{CastError, Caster, Field => V2Field, Type => V2Type}
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
+import com.snowplowanalytics.iglu.schemaddl.jsonschema.circe.implicits.toSchema
+import com.snowplowanalytics.snowplow.analytics.scalasdk.{Data => SdkData, Event, SnowplowEvent}
+import com.snowplowanalytics.snowplow.loaders.transform.{NonAtomicFields, SchemaSubVersion, TabledEntity, Transform}
+import com.snowplowanalytics.snowplow.badrows.{
+  BadRow,
+  Failure => BadRowFailure,
+  FailureDetails,
+  Payload => BadPayload,
+  Processor => BadRowProcessor
+}
+
+object LegacyColumns {
+
+  case class Result(fields: Vector[FieldForEntity], igluFailures: List[ColumnFailure])
+
+  case class FieldForEntity(
+    field: V2Field,
+    key: SchemaKey,
+    entityType: TabledEntity.EntityType
+  )
+
+  case class ColumnFailure(
+    schemaKey: SchemaKey,
+    entityType: TabledEntity.EntityType,
+    failure: FailureDetails.LoaderIgluError
+  )
+
+  def resolveTypes[F[_]: Sync: RegistryLookup](
+    resolver: Resolver[F],
+    entities: Map[TabledEntity, Set[SchemaSubVersion]]
+  ): F[Result] =
+    entities.toVector
+      .flatMap { case (tabledEntity, subVersions) =>
+        subVersions.map { subVersion =>
+          (tabledEntity.entityType, TabledEntity.toSchemaKey(tabledEntity, subVersion))
+        }
+      }
+      .traverse { case (entityType, schemaKey) =>
+        getSchema(resolver, schemaKey)
+          .map { schema =>
+            val mode = entityType match {
+              case TabledEntity.UnstructEvent => LegacyMode.Nullable
+              case TabledEntity.Context       => LegacyMode.Repeated
+            }
+            val columnName  = legacyColumnName(entityType, schemaKey)
+            val legacyField = LegacyField.build(columnName, schema, false).setMode(mode).normalized
+            val v2Field     = legacyFieldToV2Field(legacyField)
+            FieldForEntity(v2Field, schemaKey, entityType)
+          }
+          .leftMap(ColumnFailure(schemaKey, entityType, _))
+          .value
+      }
+      .map { eithers =>
+        val (failures, good) = eithers.separate
+        Result(good, failures.toList)
+      }
+
+  def transformEvent(
+    processor: BadRowProcessor,
+    event: Event,
+    batchInfo: Result,
+    loadTstamp: java.lang.Long
+  ): Either[BadRow, Map[String, AnyRef]] =
+    for {
+      _ <- failForResolverErrors(processor, event, batchInfo.igluFailures)
+      atomic <- forAtomic(processor, event)
+      nonAtomic <- forEntities(event, batchInfo.fields).leftMap { nel =>
+                     BadRow.LoaderIgluError(processor, BadRowFailure.LoaderIgluErrors(nel), BadPayload.LoaderPayload(event))
+                   }.toEither
+    } yield atomic ++ nonAtomic + ("load_tstamp" -> loadTstamp)
+
+  private def legacyFieldToV2Field(legacyField: LegacyField): V2Field = {
+    val fieldType = legacyTypeToV2Type(legacyField.fieldType)
+    legacyField.mode match {
+      case LegacyMode.Nullable =>
+        V2Field(legacyField.name, fieldType, V2Type.Nullability.Nullable)
+      case LegacyMode.Required =>
+        V2Field(legacyField.name, fieldType, V2Type.Nullability.Required)
+      case LegacyMode.Repeated =>
+        val repeatedType = V2Type.Array(fieldType, V2Type.Nullability.Nullable)
+        V2Field(legacyField.name, repeatedType, V2Type.Nullability.Nullable)
+    }
+  }
+
+  private def legacyTypeToV2Type(legacyType: LegacyType): V2Type =
+    legacyType match {
+      case LegacyType.String    => V2Type.String
+      case LegacyType.Boolean   => V2Type.Boolean
+      case LegacyType.Integer   => V2Type.Long
+      case LegacyType.Float     => V2Type.Double
+      case LegacyType.Numeric   => V2Type.Decimal(V2Type.DecimalPrecision.Digits38, 9)
+      case LegacyType.Date      => V2Type.Date
+      case LegacyType.DateTime  => V2Type.Timestamp
+      case LegacyType.Timestamp => V2Type.Timestamp
+      case LegacyType.Record(nested) =>
+        nested.toNel match {
+          case None      => V2Type.Json
+          case Some(nel) => V2Type.Struct(nel.toNev.map(legacyFieldToV2Field))
+        }
+    }
+
+  private def getSchema[F[_]: Sync: RegistryLookup](
+    resolver: Resolver[F],
+    schemaKey: SchemaKey
+  ): EitherT[F, FailureDetails.LoaderIgluError, Schema] =
+    for {
+      json <- EitherT(resolver.lookupSchema(schemaKey))
+                .leftMap(resolverBadRow(schemaKey))
+      schema <- EitherT.fromOption[F](Schema.parse(json), parseSchemaBadRow(schemaKey))
+    } yield schema
+
+  private def resolverBadRow(schemaKey: SchemaKey)(e: ClientError.ResolutionError): FailureDetails.LoaderIgluError =
+    FailureDetails.LoaderIgluError.IgluError(schemaKey, e)
+
+  private def parseSchemaBadRow(schemaKey: SchemaKey): FailureDetails.LoaderIgluError =
+    FailureDetails.LoaderIgluError.InvalidSchema(schemaKey, "Cannot be parsed as JSON Schema AST")
+
+  private implicit val eqSchemaKey: Eq[SchemaKey] = Eq.fromUniversalEquals
+
+  private def failForResolverErrors(
+    processor: BadRowProcessor,
+    event: Event,
+    failures: List[ColumnFailure]
+  ): Either[BadRow, Unit] = {
+    val schemaFailures = failures.flatMap { case ColumnFailure(failureSchemaKey, entityType, failure) =>
+      entityType match {
+        case TabledEntity.UnstructEvent =>
+          event.unstruct_event.data match {
+            case Some(SelfDescribingData(schemaKey, _)) if schemaKey === failureSchemaKey =>
+              Some(failure)
+            case _ =>
+              None
+          }
+        case TabledEntity.Context =>
+          val allContexts = event.contexts.data.iterator ++ event.derived_contexts.data.iterator
+          if (allContexts.exists(context => context.schema === failureSchemaKey))
+            Some(failure)
+          else
+            None
+      }
+    }
+
+    NonEmptyList.fromList(schemaFailures) match {
+      case None => Right(())
+      case Some(nel) =>
+        Left(BadRow.LoaderIgluError(processor, BadRowFailure.LoaderIgluErrors(nel), BadPayload.LoaderPayload(event)))
+    }
+  }
+
+  private def forAtomic(processor: BadRowProcessor, event: Event): Either[BadRow, Map[String, AnyRef]] =
+    Transform
+      .transformEvent[AnyRef](processor, BigQueryCaster, event, NonAtomicFields.Result(Vector.empty, List.empty))
+      .map { namedValues =>
+        namedValues.map { case Caster.NamedValue(k, v) =>
+          k -> v
+        }.toMap
+      }
+
+  private def forEntities(
+    event: Event,
+    entities: Vector[FieldForEntity]
+  ): ValidatedNel[FailureDetails.LoaderIgluError, Map[String, AnyRef]] =
+    entities
+      .traverse { case FieldForEntity(field, schemaKey, entityType) =>
+        val result = entityType match {
+          case TabledEntity.UnstructEvent => forUnstruct(field, schemaKey, event)
+          case TabledEntity.Context       => forContexts(field, schemaKey, event)
+        }
+        result
+          .map { fieldValue =>
+            field.name -> fieldValue
+          }
+          .leftMap { failure =>
+            castErrorToLoaderIgluError(schemaKey, failure)
+          }
+      }
+      .map(_.toMap)
+
+  private def castErrorToLoaderIgluError(
+    schemaKey: SchemaKey,
+    castErrors: NonEmptyList[CastError]
+  ): NonEmptyList[FailureDetails.LoaderIgluError] =
+    castErrors.map {
+      case CastError.WrongType(v, e)      => FailureDetails.LoaderIgluError.WrongType(schemaKey, v, e.toString)
+      case CastError.MissingInValue(k, v) => FailureDetails.LoaderIgluError.MissingInValue(schemaKey, k, v)
+    }
+
+  private def forUnstruct(
+    field: V2Field,
+    schemaKey: SchemaKey,
+    event: Event
+  ): ValidatedNel[CastError, AnyRef] =
+    event.unstruct_event.data match {
+      case Some(SelfDescribingData(key2, unstructData)) if schemaKey === key2 =>
+        Caster.cast(BigQueryCaster, field, unstructData)
+      case _ =>
+        Validated.Valid(null)
+    }
+
+  private def forContexts[A](
+    field: V2Field,
+    schemaKey: SchemaKey,
+    event: Event
+  ): ValidatedNel[CastError, AnyRef] = {
+    val allContexts = event.contexts.data ::: event.derived_contexts.data
+    val matchingContexts = allContexts
+      .filter(context => context.schema === schemaKey)
+
+    if (matchingContexts.nonEmpty)
+      Caster.cast(BigQueryCaster, field, Json.fromValues(matchingContexts.map(_.data)))
+    else
+      Validated.Valid(null)
+  }
+
+  private def legacyColumnName(entityType: TabledEntity.EntityType, schemaKey: SchemaKey): String = {
+    val SchemaVer.Full(model, revision, addition) = schemaKey.version
+    val shredProperty = entityType match {
+      case TabledEntity.UnstructEvent => SdkData.UnstructEvent
+      case TabledEntity.Context       => SdkData.Contexts(SdkData.CustomContexts)
+    }
+    val v2Name = SnowplowEvent.transformSchema(shredProperty, schemaKey.vendor, schemaKey.name, model)
+    s"${v2Name}_${revision}_${addition}"
+  }
+
+}

--- a/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/invalid_syntax/jsonschema/1-0-0
+++ b/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/invalid_syntax/jsonschema/1-0-0
@@ -1,0 +1,3 @@
+{
+  "properties": "this should not be a string"
+}

--- a/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/7-0-0
+++ b/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/7-0-0
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "myvendor",
+    "name": "myschema",
+    "format": "jsonschema",
+    "version": "7-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "col_a": {"type": "string"}
+  },
+  "required": ["col_a"]
+}

--- a/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/7-0-1
+++ b/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/7-0-1
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "myvendor",
+    "name": "myschema",
+    "format": "jsonschema",
+    "version": "7-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "col_a": {"type": "string"},
+    "col_b": {"type": "string"}
+  },
+  "required": ["col_a", "col_b"]
+}

--- a/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/7-1-0
+++ b/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/7-1-0
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "myvendor",
+    "name": "myschema",
+    "format": "jsonschema",
+    "version": "7-1-0"
+  },
+  "type": "object",
+  "properties": {
+    "col_a": {"type": "string"},
+    "col_c": {"type": "integer"}
+  },
+  "required": ["col_a"]
+}

--- a/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/8-0-0
+++ b/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/8-0-0
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "myvendor",
+    "name": "myschema",
+    "format": "jsonschema",
+    "version": "8-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "col_x": {"type": "string"}
+  },
+  "required": ["col_x"]
+}

--- a/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/9-0-0
+++ b/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/9-0-0
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "myvendor",
+    "name": "myschema",
+    "format": "jsonschema",
+    "version": "9-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "col_z": {"type": "string"}
+  },
+  "required": ["col_z"]
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -17,6 +17,7 @@ import com.google.protobuf.Descriptors
 import com.google.cloud.bigquery.FieldList
 
 import com.snowplowanalytics.iglu.client.Resolver
+import com.snowplowanalytics.iglu.core.SchemaCriterion
 import com.snowplowanalytics.iglu.schemaddl.parquet.Field
 import com.snowplowanalytics.snowplow.runtime.AppInfo
 import com.snowplowanalytics.snowplow.runtime.processing.Coldswap
@@ -58,14 +59,14 @@ object MockEnvironment {
    * @param mocks
    *   Responses we want the `Writer` to return when someone calls uses the mocked services
    * @param legacyColumns
-   *   Whether to use legacy column style of BigQuery Loader version 1
+   *   Schemas for which to use legacy column style of BigQuery Loader version 1
    * @return
    *   An environment and a Ref that records the actions make by the environment
    */
   def build(
     inputs: List[TokenedEvents],
     mocks: Mocks,
-    legacyColumns: Boolean
+    legacyColumns: List[SchemaCriterion]
   ): Resource[IO, MockEnvironment] =
     for {
       state <- Resource.eval(Ref[IO].of(Vector.empty[Action]))

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -57,10 +57,16 @@ object MockEnvironment {
    *   Input events to send into the environment.
    * @param mocks
    *   Responses we want the `Writer` to return when someone calls uses the mocked services
+   * @param legacyColumns
+   *   Whether to use legacy column style of BigQuery Loader version 1
    * @return
    *   An environment and a Ref that records the actions make by the environment
    */
-  def build(inputs: List[TokenedEvents], mocks: Mocks): Resource[IO, MockEnvironment] =
+  def build(
+    inputs: List[TokenedEvents],
+    mocks: Mocks,
+    legacyColumns: Boolean
+  ): Resource[IO, MockEnvironment] =
     for {
       state <- Resource.eval(Ref[IO].of(Vector.empty[Action]))
       writerResource <- Resource.eval(testWriter(state, mocks.writerResponses, mocks.descriptors))
@@ -86,7 +92,7 @@ object MockEnvironment {
         ),
         badRowMaxSize = 1000000,
         schemasToSkip = List.empty,
-        legacyColumns = false
+        legacyColumns = legacyColumns
       )
       MockEnvironment(state, env)
     }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -85,7 +85,8 @@ object MockEnvironment {
           writeBatchConcurrency = 1
         ),
         badRowMaxSize = 1000000,
-        schemasToSkip = List.empty
+        schemasToSkip = List.empty,
+        legacyColumns = false
       )
       MockEnvironment(state, env)
     }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
@@ -13,7 +13,7 @@ import org.specs2.Specification
 import cats.effect.testing.specs2.CatsEffect
 import com.snowplowanalytics.iglu.client.Resolver
 import com.snowplowanalytics.iglu.client.resolver.registries.JavaNetRegistryLookup._
-import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer}
 import com.snowplowanalytics.iglu.schemaddl.parquet.{Field, Type}
 import com.snowplowanalytics.iglu.schemaddl.parquet.Type.Nullability.{Nullable, Required}
 import com.snowplowanalytics.snowplow.badrows.FailureDetails
@@ -29,12 +29,14 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       return multiple schemas if the batch uses multiple schemas from a series $ue2
       return a JSON field for the Iglu Central ad_break_end_event schema $ue3
       return a JSON field for the Iglu Central anything-a schema $ue4
+      return nothing if this is not a legacy schema $ue5
 
     when resolving for known schemas in contexts should
       return a single schema if the batch uses a single schema in a series $c1
       return multiple schemas if the batch uses multiple schemas from a series $c2
       return a JSON field for the Iglu Central ad_break_end_event schema $c3
       return a JSON field for the Iglu Central anything-a schema $c4
+      return nothing if this is not a legacy schema $c5
 
     when resolving for known schema in contexts and unstruct_event should
       return separate entity for the context and the unstruct_event $both1
@@ -42,6 +44,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
     when handling Iglu failures should
       return a IgluError if schema key does not exist in a valid series of schemas $fail1
       return an InvalidSchema if the series contains a schema that cannot be parsed $fail2
+      return no failures if this is not a legacy schema $fail3
   """
 
   def ue1 = {
@@ -68,7 +71,9 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       )
     }
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -117,7 +122,9 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       )
     }
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(2)) and
         (fields must contain(expected100)) and
@@ -147,7 +154,9 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       )
     }
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("com.snowplowanalytics.snowplow.media", "ad_break_end_event", "jsonschema", 1))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -175,10 +184,30 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       )
     }
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("com.snowplowanalytics.iglu", "anything-a", "jsonschema", 1))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
+    }
+
+  }
+
+  def ue5 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.UnstructEvent, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    // non-matching schema criteria:
+    val legacyCriteria = List(SchemaCriterion("myvendor", "different", "jsonschema", 7))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must beEmpty)
     }
 
   }
@@ -209,7 +238,9 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       )
     }
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -262,7 +293,9 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       )
     }
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(2)) and
         (fields must contain(expected100)) and
@@ -292,7 +325,9 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       )
     }
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("com.snowplowanalytics.snowplow.media", "ad_break_end_event", "jsonschema", 1))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -324,10 +359,30 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       )
     }
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("com.snowplowanalytics.iglu", "anything-a", "jsonschema", 1))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
+    }
+
+  }
+
+  def c5 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.Context, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    // non-matching schema criteria
+    val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 4))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must beEmpty)
     }
 
   }
@@ -342,7 +397,9 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       tabledEntity2 -> Set((0, 0))
     )
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(2)) and
         (fields.map(_.entityType) must contain(allOf[TabledEntity.EntityType](TabledEntity.UnstructEvent, TabledEntity.Context)))
@@ -360,7 +417,9 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val expectedKey = SchemaKey("myvendor", "myschema", "jsonschema", SchemaVer.Full(7, 0, 9))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (fields must beEmpty) and
         (failures must haveSize(1)) and
         (failures.head must beLike { case failure: LegacyColumns.ColumnFailure =>
@@ -381,13 +440,33 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val expectedKey = SchemaKey("myvendor", "invalid_syntax", "jsonschema", SchemaVer.Full(1, 0, 0))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+    val legacyCriteria = List(SchemaCriterion("myvendor", "invalid_syntax", "jsonschema", 1))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
       (fields must beEmpty) and
         (failures must haveSize(1)) and
         (failures.head must beLike { case failure: LegacyColumns.ColumnFailure =>
           (failure.schemaKey must beEqualTo(expectedKey)) and
             (failure.failure must beLike { case _: FailureDetails.LoaderIgluError.InvalidSchema => ok })
         })
+    }
+
+  }
+
+  def fail3 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.UnstructEvent, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity -> Set((0, 9))
+    )
+
+    // non-matching crieria
+    val legacyCriteria = List(SchemaCriterion("other.vendor", "myschema", "jsonschema", 7))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+      (fields must beEmpty) and
+        (failures must beEmpty)
     }
 
   }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.bigquery.processing
+
+import cats.effect.IO
+import cats.data.NonEmptyVector
+import org.specs2.Specification
+import cats.effect.testing.specs2.CatsEffect
+import com.snowplowanalytics.iglu.client.Resolver
+import com.snowplowanalytics.iglu.client.resolver.registries.JavaNetRegistryLookup._
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer}
+import com.snowplowanalytics.iglu.schemaddl.parquet.{Field, Type}
+import com.snowplowanalytics.iglu.schemaddl.parquet.Type.Nullability.{Nullable, Required}
+import com.snowplowanalytics.snowplow.badrows.FailureDetails
+import com.snowplowanalytics.snowplow.loaders.transform.TabledEntity
+
+class LegacyColumnsResolveSpec extends Specification with CatsEffect {
+  import LegacyColumnsResolveSpec._
+
+  def is = s2"""
+  LegacyColumns.resolveTypes
+    when resolving for known schemas in unstruct_event should
+      return a single schema if the batch uses a single schema in a series $ue1
+      return multiple schemas if the batch uses multiple schemas from a series $ue2
+      return a JSON field for the Iglu Central ad_break_end_event schema $ue3
+      return a JSON field for the Iglu Central anything-a schema $ue4
+
+    when resolving for known schemas in contexts should
+      return a single schema if the batch uses a single schema in a series $c1
+      return multiple schemas if the batch uses multiple schemas from a series $c2
+      return a JSON field for the Iglu Central ad_break_end_event schema $c3
+      return a JSON field for the Iglu Central anything-a schema $c4
+
+    when resolving for known schema in contexts and unstruct_event should
+      return separate entity for the context and the unstruct_event $both1
+
+    when handling Iglu failures should
+      return a IgluError if schema key does not exist in a valid series of schemas $fail1
+      return an InvalidSchema if the series contains a schema that cannot be parsed $fail2
+  """
+
+  def ue1 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.UnstructEvent, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    val expected = {
+      val expectedStruct = Type.Struct(
+        NonEmptyVector.of(
+          Field("col_a", Type.Json, Required)
+        )
+      )
+
+      val expectedField = Field("unstruct_event_myvendor_myschema_7_0_0", expectedStruct, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("myvendor", "myschema", "jsonschema", SchemaVer.Full(7, 0, 0)),
+        TabledEntity.UnstructEvent
+      )
+    }
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(1)) and
+        (fields must contain(expected))
+    }
+
+  }
+
+  def ue2 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.UnstructEvent, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0), (1, 0))
+    )
+
+    val expected100 = {
+      val expectedStruct = Type.Struct(
+        NonEmptyVector.of(
+          Field("col_a", Type.Json, Required)
+        )
+      )
+
+      val expectedField = Field("unstruct_event_myvendor_myschema_7_0_0", expectedStruct, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("myvendor", "myschema", "jsonschema", SchemaVer.Full(7, 0, 0)),
+        TabledEntity.UnstructEvent
+      )
+    }
+
+    val expected110 = {
+      val expectedStruct = Type.Struct(
+        NonEmptyVector.of(
+          Field("col_a", Type.Json, Required),
+          Field("col_c", Type.Long, Nullable)
+        )
+      )
+
+      val expectedField = Field("unstruct_event_myvendor_myschema_7_1_0", expectedStruct, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("myvendor", "myschema", "jsonschema", SchemaVer.Full(7, 1, 0)),
+        TabledEntity.UnstructEvent
+      )
+    }
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(2)) and
+        (fields must contain(expected100)) and
+        (fields must contain(expected110))
+    }
+
+  }
+
+  def ue3 = {
+
+    // Example of a schema which is an empty object with no additional properties
+    val tabledEntity = TabledEntity(TabledEntity.UnstructEvent, "com.snowplowanalytics.snowplow.media", "ad_break_end_event", 1)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    val expected = {
+      val expectedType = Type.Json
+      val expectedField =
+        Field("unstruct_event_com_snowplowanalytics_snowplow_media_ad_break_end_event_1_0_0", expectedType, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("com.snowplowanalytics.snowplow.media", "ad_break_end_event", "jsonschema", SchemaVer.Full(1, 0, 0)),
+        TabledEntity.UnstructEvent
+      )
+    }
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(1)) and
+        (fields must contain(expected))
+    }
+
+  }
+
+  def ue4 = {
+
+    // Example of a permissive schema which permits any JSON
+    val tabledEntity = TabledEntity(TabledEntity.UnstructEvent, "com.snowplowanalytics.iglu", "anything-a", 1)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    val expected = {
+      val expectedType  = Type.Json
+      val expectedField = Field("unstruct_event_com_snowplowanalytics_iglu_anything_a_1_0_0", expectedType, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("com.snowplowanalytics.iglu", "anything-a", "jsonschema", SchemaVer.Full(1, 0, 0)),
+        TabledEntity.UnstructEvent
+      )
+    }
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(1)) and
+        (fields must contain(expected))
+    }
+
+  }
+
+  def c1 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.Context, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    val expected = {
+      val expectedStruct = Type.Struct(
+        NonEmptyVector.of(
+          Field("col_a", Type.Json, Required)
+        )
+      )
+
+      val expectedArray = Type.Array(expectedStruct, Nullable)
+
+      val expectedField = Field("contexts_myvendor_myschema_7_0_0", expectedArray, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("myvendor", "myschema", "jsonschema", SchemaVer.Full(7, 0, 0)),
+        TabledEntity.Context
+      )
+    }
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(1)) and
+        (fields must contain(expected))
+    }
+
+  }
+
+  def c2 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.Context, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0), (1, 0))
+    )
+
+    val expected100 = {
+      val expectedStruct = Type.Struct(
+        NonEmptyVector.of(
+          Field("col_a", Type.Json, Required)
+        )
+      )
+
+      val expectedArray = Type.Array(expectedStruct, Nullable)
+
+      val expectedField = Field("contexts_myvendor_myschema_7_0_0", expectedArray, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("myvendor", "myschema", "jsonschema", SchemaVer.Full(7, 0, 0)),
+        TabledEntity.Context
+      )
+    }
+
+    val expected110 = {
+      val expectedStruct = Type.Struct(
+        NonEmptyVector.of(
+          Field("col_a", Type.Json, Required),
+          Field("col_c", Type.Long, Nullable)
+        )
+      )
+
+      val expectedArray = Type.Array(expectedStruct, Nullable)
+
+      val expectedField = Field("contexts_myvendor_myschema_7_1_0", expectedArray, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("myvendor", "myschema", "jsonschema", SchemaVer.Full(7, 1, 0)),
+        TabledEntity.Context
+      )
+    }
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(2)) and
+        (fields must contain(expected100)) and
+        (fields must contain(expected110))
+    }
+
+  }
+
+  def c3 = {
+
+    // Example of a schema which is an empty object with no additional properties
+    val tabledEntity = TabledEntity(TabledEntity.Context, "com.snowplowanalytics.snowplow.media", "ad_break_end_event", 1)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    val expected = {
+      val expectedArray = Type.Array(Type.Json, Nullable)
+      val expectedField =
+        Field("contexts_com_snowplowanalytics_snowplow_media_ad_break_end_event_1_0_0", expectedArray, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("com.snowplowanalytics.snowplow.media", "ad_break_end_event", "jsonschema", SchemaVer.Full(1, 0, 0)),
+        TabledEntity.Context
+      )
+    }
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(1)) and
+        (fields must contain(expected))
+    }
+
+  }
+
+  def c4 = {
+
+    // Example of a permissive schema which permits any JSON
+    val tabledEntity = TabledEntity(TabledEntity.Context, "com.snowplowanalytics.iglu", "anything-a", 1)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    val expected = {
+
+      val expectedType = Type.Json
+
+      val expectedArray = Type.Array(expectedType, Nullable)
+
+      val expectedField = Field("contexts_com_snowplowanalytics_iglu_anything_a_1_0_0", expectedArray, Nullable, Set.empty)
+
+      LegacyColumns.FieldForEntity(
+        expectedField,
+        SchemaKey("com.snowplowanalytics.iglu", "anything-a", "jsonschema", SchemaVer.Full(1, 0, 0)),
+        TabledEntity.Context
+      )
+    }
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(1)) and
+        (fields must contain(expected))
+    }
+
+  }
+
+  def both1 = {
+
+    val tabledEntity1 = TabledEntity(TabledEntity.UnstructEvent, "myvendor", "myschema", 7)
+    val tabledEntity2 = TabledEntity(TabledEntity.Context, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity1 -> Set((0, 0)),
+      tabledEntity2 -> Set((0, 0))
+    )
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (failures must beEmpty) and
+        (fields must haveSize(2)) and
+        (fields.map(_.entityType) must contain(allOf[TabledEntity.EntityType](TabledEntity.UnstructEvent, TabledEntity.Context)))
+    }
+
+  }
+
+  def fail1 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.UnstructEvent, "myvendor", "myschema", 7)
+
+    val input = Map(
+      tabledEntity -> Set((0, 9))
+    )
+
+    val expectedKey = SchemaKey("myvendor", "myschema", "jsonschema", SchemaVer.Full(7, 0, 9))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (fields must beEmpty) and
+        (failures must haveSize(1)) and
+        (failures.head must beLike { case failure: LegacyColumns.ColumnFailure =>
+          (failure.schemaKey must beEqualTo(expectedKey)) and
+            (failure.failure must beLike { case _: FailureDetails.LoaderIgluError.IgluError => ok })
+        })
+    }
+
+  }
+
+  def fail2 = {
+
+    val tabledEntity = TabledEntity(TabledEntity.UnstructEvent, "myvendor", "invalid_syntax", 1)
+
+    val input = Map(
+      tabledEntity -> Set((0, 0))
+    )
+
+    val expectedKey = SchemaKey("myvendor", "invalid_syntax", "jsonschema", SchemaVer.Full(1, 0, 0))
+
+    LegacyColumns.resolveTypes(embeddedResolver, input).map { case LegacyColumns.Result(fields, failures) =>
+      (fields must beEmpty) and
+        (failures must haveSize(1)) and
+        (failures.head must beLike { case failure: LegacyColumns.ColumnFailure =>
+          (failure.schemaKey must beEqualTo(expectedKey)) and
+            (failure.failure must beLike { case _: FailureDetails.LoaderIgluError.InvalidSchema => ok })
+        })
+    }
+
+  }
+
+}
+
+object LegacyColumnsResolveSpec {
+
+  // A resolver that resolves embedded schemas only
+  val embeddedResolver = Resolver[IO](Nil, None)
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsTransformSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsTransformSpec.scala
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.bigquery.processing
+
+import cats.data.NonEmptyVector
+import org.specs2.Specification
+import org.specs2.matcher.MatchResult
+import io.circe.Json
+import io.circe.literal._
+import io.circe.parser.{parse => parseAsCirce}
+import org.json.{JSONArray, JSONObject}
+
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.iglu.client.ClientError.ResolutionError
+import com.snowplowanalytics.iglu.schemaddl.parquet.{Field, Type}
+import com.snowplowanalytics.iglu.schemaddl.parquet.Type.Nullability.{Nullable, Required}
+import com.snowplowanalytics.snowplow.analytics.scalasdk.{Event, SnowplowEvent}
+import com.snowplowanalytics.snowplow.badrows.{BadRow, Failure, FailureDetails, Processor => BadRowProcessor}
+import com.snowplowanalytics.snowplow.loaders.transform.TabledEntity
+
+import java.util.UUID
+import java.time.Instant
+import scala.collection.immutable.SortedMap
+
+class LegacyColumnsTransformSpec extends Specification {
+  import LegacyColumnsTransformSpec._
+
+  def is = s2"""
+  LegacyColumns.transformEvent should
+    Transform an event with only atomic fields (no custom entities) $onlyAtomic
+    Transform an event with one custom context $oneContext
+    Transform an event with an unstruct event $unstruct
+    Transform an event with each different type of atomic field $onlyAtomicAllTypes
+    Transform an unstruct event with each different type $unstructAllTypes
+    Transform a context with different type $contextAllTypes
+    Produce JSON null on output for unstruct column if no data matching type is provided $unstructNoData
+    Produce JSON null on output for contexts column if no data matching type is provided $contextsNoData
+
+  Failures:
+    Atomic currency field cannot be cast to a decimal due to rounding $atomicTooManyDecimalPoints
+    Atomic currency field cannot be cast to a decimal due to high precision $atomicHighPrecision
+    Missing value for unstruct (missing required field) $unstructMissingValue
+    Missing value for unstruct (null passed in required field) $unstructNullValue
+    Missing value for context (missing required field) $contextMissingValue
+    Missing value for context (null passed in required field) $contextNullValue
+    Cast error for unstruct (integer passed in string field) $unstructWrongType
+    Cast error for context (integer passed in string field) $contextWrongType
+    Iglu error in batch info becomes iglu transformation error $igluErrorInBatchInfo
+  """
+
+  def onlyAtomic = {
+    val event     = createEvent()
+    val batchInfo = LegacyColumns.Result(Vector.empty, List.empty) // no custom entities
+    val expectedAtomic: Map[String, AnyRef] = Map(
+      "event_id" -> eventId.toString,
+      "collector_tstamp" -> collectorTstampMicros,
+      "geo_region" -> null,
+      "load_tstamp" -> nowMicros
+    )
+
+    assertSuccessful(event, batchInfo, expectedAtomic = expectedAtomic)
+  }
+
+  def oneContext = {
+    val inputEvent =
+      createEvent(contexts = List(sdj(data = json"""{ "my_int": 42}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaContexts(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+    val expectedOutput = Map(
+      "contexts_com_example_my_schema_1_0_0" -> json"""[{"my_int": 42}]"""
+    )
+
+    assertSuccessful(inputEvent, batchInfo, expectedAllEntities = expectedOutput)
+  }
+
+  def unstruct = {
+    val inputEvent =
+      createEvent(unstruct = Some(sdj(data = json"""{ "my_int": 42}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaUnstruct(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+    val expectedOutput = Map(
+      "unstruct_event_com_example_my_schema_1_0_0" -> json"""{"my_int": 42}"""
+    )
+
+    assertSuccessful(inputEvent, batchInfo, expectedAllEntities = expectedOutput)
+  }
+
+  def onlyAtomicAllTypes = {
+    val event = createEvent()
+      .copy(
+        app_id              = Some("myapp"),
+        dvce_created_tstamp = Some(now),
+        txn_id              = Some(42),
+        geo_latitude        = Some(1.234),
+        dvce_ismobile       = Some(true),
+        tr_total            = Some(12.34)
+      )
+
+    val batchInfo = LegacyColumns.Result(Vector.empty, List.empty) // no custom entities
+    val expectedOutput: Map[String, AnyRef] = Map(
+      "app_id" -> "myapp",
+      "dvce_created_tstamp" -> Long.box(nowMicros),
+      "txn_id" -> Int.box(42),
+      "geo_latitude" -> Double.box(1.234),
+      "dvce_ismobile" -> Boolean.box(true),
+      "tr_total" -> new java.math.BigDecimal("12.34")
+    )
+
+    assertSuccessful(event, batchInfo, expectedAtomic = expectedOutput)
+  }
+
+  def atomicTooManyDecimalPoints = {
+    val inputEvent = createEvent()
+      .copy(
+        tr_total         = Some(12.3456),
+        tr_tax           = Some(12.3456),
+        tr_shipping      = Some(12.3456),
+        ti_price         = Some(12.3456),
+        tr_total_base    = Some(12.3456),
+        tr_tax_base      = Some(12.3456),
+        tr_shipping_base = Some(12.3456),
+        ti_price_base    = Some(12.3456)
+      )
+
+    val batchInfo = LegacyColumns.Result(Vector.empty, List.empty)
+
+    val wrongType = FailureDetails.LoaderIgluError.WrongType(
+      SchemaKey("com.snowplowanalytics.snowplow", "atomic", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      value    = json"12.3456",
+      expected = "Decimal(Digits18,2)"
+    )
+
+    val expectedErrors = List.fill(8)(wrongType)
+
+    assertLoaderError(inputEvent, batchInfo, expectedErrors)
+  }
+
+  def atomicHighPrecision = {
+    val inputEvent = createEvent()
+      .copy(
+        tr_total         = Some(12345678987654321.34),
+        tr_tax           = Some(12345678987654321.34),
+        tr_shipping      = Some(12345678987654321.34),
+        ti_price         = Some(12345678987654321.34),
+        tr_total_base    = Some(12345678987654321.34),
+        tr_tax_base      = Some(12345678987654321.34),
+        tr_shipping_base = Some(12345678987654321.34),
+        ti_price_base    = Some(12345678987654321.34)
+      )
+
+    val batchInfo = LegacyColumns.Result(Vector.empty, List.empty)
+
+    val wrongType = FailureDetails.LoaderIgluError.WrongType(
+      SchemaKey("com.snowplowanalytics.snowplow", "atomic", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      value    = json"1.2345678987654322E16",
+      expected = "Decimal(Digits18,2)"
+    )
+
+    val expectedErrors = List.fill(8)(wrongType)
+
+    assertLoaderError(inputEvent, batchInfo, expectedErrors)
+  }
+
+  def unstructMissingValue = {
+    val inputEvent =
+      createEvent(unstruct = Some(sdj(data = json"""{}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaUnstruct(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+
+    val expectedError = FailureDetails.LoaderIgluError.WrongType(
+      SchemaKey("com.example", "mySchema", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      value    = json"""null""",
+      expected = "Integer"
+    )
+
+    assertLoaderError(inputEvent, batchInfo, List(expectedError))
+  }
+
+  def unstructNullValue = {
+    val inputEvent =
+      createEvent(unstruct = Some(sdj(data = json"""{ "my_int": null}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaUnstruct(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+
+    val expectedError = FailureDetails.LoaderIgluError.WrongType(
+      SchemaKey("com.example", "mySchema", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      value    = Json.Null,
+      expected = "Integer"
+    )
+
+    assertLoaderError(inputEvent, batchInfo, List(expectedError))
+  }
+
+  def contextMissingValue = {
+    val inputEvent =
+      createEvent(contexts = List(sdj(data = json"""{}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaContexts(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+
+    val expectedError = FailureDetails.LoaderIgluError.WrongType(
+      SchemaKey("com.example", "mySchema", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      value    = json"""null""",
+      expected = "Integer"
+    )
+
+    assertLoaderError(inputEvent, batchInfo, List(expectedError))
+  }
+
+  def contextNullValue = {
+    val inputEvent =
+      createEvent(contexts = List(sdj(data = json"""{ "my_int": null}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaContexts(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+
+    val expectedError = FailureDetails.LoaderIgluError.WrongType(
+      SchemaKey("com.example", "mySchema", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      value    = Json.Null,
+      expected = "Integer"
+    )
+
+    assertLoaderError(inputEvent, batchInfo, List(expectedError))
+  }
+
+  def unstructWrongType = {
+    val inputEvent =
+      createEvent(unstruct = Some(sdj(data = json"""{ "my_int": "xyz"}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaUnstruct(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+
+    val expectedError = FailureDetails.LoaderIgluError.WrongType(
+      SchemaKey("com.example", "mySchema", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      value    = json""""xyz"""",
+      expected = "Integer"
+    )
+
+    assertLoaderError(inputEvent, batchInfo, List(expectedError))
+  }
+
+  def contextWrongType = {
+    val inputEvent =
+      createEvent(contexts = List(sdj(data = json"""{ "my_int": "xyz"}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaContexts(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+
+    val expectedError = FailureDetails.LoaderIgluError.WrongType(
+      SchemaKey("com.example", "mySchema", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      value    = json""""xyz"""",
+      expected = "Integer"
+    )
+
+    assertLoaderError(inputEvent, batchInfo, List(expectedError))
+  }
+
+  def igluErrorInBatchInfo = {
+    val inputEvent =
+      createEvent(unstruct = Some(sdj(data = json"""{ "my_int": 42}""", key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+
+    val igluResolutionError = FailureDetails.LoaderIgluError.SchemaListNotFound(
+      SchemaCriterion("com.example", "mySchema", "jsonschema", 1),
+      ResolutionError(SortedMap.empty)
+    )
+
+    val batchInfo = LegacyColumns.Result(
+      fields = Vector.empty,
+      igluFailures = List(
+        LegacyColumns.ColumnFailure(
+          SchemaKey("com.example", "mySchema", "jsonschema", SchemaVer.Full(1, 0, 0)),
+          TabledEntity.UnstructEvent,
+          igluResolutionError
+        )
+      )
+    )
+
+    assertLoaderError(inputEvent, batchInfo, expectedErrors = List(igluResolutionError))
+  }
+
+  def unstructAllTypes = {
+    val inputEvent =
+      createEvent(unstruct = Some(sdj(data = dataWithAllTypes, key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaUnstruct(SchemaVer.Full(1, 0, 0), schemaWithAllPossibleTypes)),
+      igluFailures = List.empty
+    )
+    val expectedOutput = Map(
+      "unstruct_event_com_example_my_schema_1_0_0" -> json"""{
+        "my_string":   "abc",
+        "my_int":       42,
+        "my_long":      42000000000,
+        "my_decimal":   1.23,
+        "my_double":    1.2323,
+        "my_boolean":   true,
+        "my_date":      19801,
+        "my_timestamp": 1710879639000000,
+        "my_array":     [1,2,3],
+        "my_object":    {"abc": "xyz"},
+        "my_empty_object": "{}"
+      }"""
+    )
+
+    assertSuccessful(inputEvent, batchInfo, expectedAllEntities = expectedOutput)
+  }
+
+  def contextAllTypes = {
+    val inputEvent =
+      createEvent(contexts = List(sdj(data = dataWithAllTypes, key = "iglu:com.example/mySchema/jsonschema/1-0-0")))
+    val batchInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaContexts(SchemaVer.Full(1, 0, 0), schemaWithAllPossibleTypes)),
+      igluFailures = List.empty
+    )
+    val expectedOutput = Map(
+      "contexts_com_example_my_schema_1_0_0" -> json"""[{
+        "my_string":   "abc",
+        "my_int":       42,
+        "my_long":      42000000000,
+        "my_decimal":   1.23,
+        "my_double":    1.2323,
+        "my_boolean":   true,
+        "my_date":      19801,
+        "my_timestamp": 1710879639000000,
+        "my_array":     [1,2,3],
+        "my_object":    {"abc": "xyz"},
+        "my_empty_object": "{}"
+      }]"""
+    )
+
+    assertSuccessful(inputEvent, batchInfo, expectedAllEntities = expectedOutput)
+  }
+
+  def unstructNoData = {
+    val inputEvent = createEvent()
+
+    val batchTypesInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaUnstruct(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+    val expectedOutput = Map(
+      "unstruct_event_com_example_my_schema_1_0_0" -> null
+    )
+
+    assertSuccessful(inputEvent, batchTypesInfo, expectedAllEntities = expectedOutput)
+  }
+
+  def contextsNoData = {
+    val inputEvent = createEvent()
+
+    val batchTypesInfo = LegacyColumns.Result(
+      fields       = Vector(mySchemaContexts(version = SchemaVer.Full(1, 0, 0))),
+      igluFailures = List.empty
+    )
+    val expectedOutput = Map(
+      "contexts_com_example_my_schema_1_0_0" -> null
+    )
+
+    assertSuccessful(inputEvent, batchTypesInfo, expectedAllEntities = expectedOutput)
+  }
+
+  private def assertSuccessful(
+    event: Event,
+    batchInfo: LegacyColumns.Result,
+    expectedAtomic: Map[String, AnyRef]    = Map.empty,
+    expectedAllEntities: Map[String, Json] = Map.empty
+  ) = {
+    val result = LegacyColumns.transformEvent(BadRowProcessor("test-loader", "0.0.0"), event, batchInfo, nowMicros)
+
+    result must beRight { actualValues: Map[String, AnyRef] =>
+      val actualFieldNames = actualValues.keys
+      val actualValuesAsCirce = actualValues.map {
+        case (k, arr: JSONArray)  => k -> parseAsCirce(arr.toString).toOption.get
+        case (k, obj: JSONObject) => k -> parseAsCirce(obj.toString).toOption.get
+        case (k, other)           => k -> other
+      }
+
+      val assertAtomicExist: MatchResult[Any]   = actualValues must containAllOf(expectedAtomic.toSeq)
+      val assertEntitiesExist: MatchResult[Any] = actualValuesAsCirce must containAllOf(expectedAllEntities.toSeq)
+      val totalNumberOfFields: MatchResult[Any] =
+        actualFieldNames.size must beEqualTo(129 + expectedAllEntities.size) // atomic + entities only
+
+      assertAtomicExist and assertEntitiesExist and totalNumberOfFields
+    }
+  }
+
+  private def assertLoaderError(
+    inputEvent: Event,
+    batchInfo: LegacyColumns.Result,
+    expectedErrors: List[FailureDetails.LoaderIgluError]
+  ): MatchResult[Either[BadRow, Map[String, AnyRef]]] = {
+    val result = LegacyColumns.transformEvent(BadRowProcessor("test-loader", "0.0.0"), inputEvent, batchInfo, nowMicros)
+
+    result must beLeft.like { case BadRow.LoaderIgluError(_, Failure.LoaderIgluErrors(errors), _) =>
+      errors.toList must containTheSameElementsAs(expectedErrors)
+    }
+  }
+
+}
+
+object LegacyColumnsTransformSpec {
+
+  private val simpleOneFieldSchema =
+    NonEmptyVector.of(
+      Field("my_int", Type.Integer, Required)
+    )
+
+  private val schemaWithAllPossibleTypes =
+    NonEmptyVector.of(
+      Field("my_string", Type.Json, Required),
+      Field("my_int", Type.Integer, Required),
+      Field("my_long", Type.Long, Required),
+      Field("my_decimal", Type.Decimal(Type.DecimalPrecision.Digits9, 2), Required),
+      Field("my_double", Type.Double, Required),
+      Field("my_boolean", Type.Boolean, Required),
+      Field("my_date", Type.Date, Required),
+      Field("my_timestamp", Type.Timestamp, Required),
+      Field("my_array", Type.Array(Type.Integer, Required), Required),
+      Field("my_object", Type.Struct(NonEmptyVector.of(Field("abc", Type.String, Required))), Required),
+      Field("my_empty_object", Type.Json, Required),
+      Field("my_null", Type.String, Nullable)
+    )
+
+  private val dataWithAllTypes = json"""
+   {
+     "my_string":   "abc",
+     "my_int":       42,
+     "my_long":      42000000000,
+     "my_decimal":   1.23,
+     "my_double":    1.2323,
+     "my_boolean":   true,
+     "my_date":      "2024-03-19",
+     "my_timestamp": "2024-03-19T20:20:39Z",
+     "my_array":     [1,2,3],
+     "my_object":    {"abc": "xyz"},
+     "my_null":      null,
+     "my_empty_object": {}
+   }
+   """
+
+  private val now                   = Instant.now
+  private val nowMicros             = Long.box(now.toEpochMilli * 1000)
+  private val collectorTstamp       = now.minusSeconds(42L)
+  private val collectorTstampMicros = Long.box(collectorTstamp.toEpochMilli * 1000)
+  private val eventId               = UUID.randomUUID()
+
+  private def createEvent(unstruct: Option[SelfDescribingData[Json]] = None, contexts: List[SelfDescribingData[Json]] = List.empty): Event =
+    Event
+      .minimal(eventId, collectorTstamp, "0.0.0", "0.0.0")
+      .copy(unstruct_event = SnowplowEvent.UnstructEvent(unstruct))
+      .copy(contexts = SnowplowEvent.Contexts(contexts))
+
+  private def sdj(data: Json, key: String): SelfDescribingData[Json] =
+    SelfDescribingData[Json](SchemaKey.fromUri(key).toOption.get, data)
+
+  private def mySchemaContexts(
+    version: SchemaVer.Full,
+    ddl: NonEmptyVector[Field] = simpleOneFieldSchema
+  ): LegacyColumns.FieldForEntity =
+    LegacyColumns.FieldForEntity(
+      field = Field(
+        s"contexts_com_example_my_schema_${version.model}_${version.revision}_${version.addition}",
+        Type.Array(Type.Struct(ddl), Nullable),
+        Nullable
+      ),
+      key        = SchemaKey("com.example", "mySchema", "jsonschema", version),
+      entityType = TabledEntity.Context
+    )
+
+  private def mySchemaUnstruct(
+    version: SchemaVer.Full,
+    ddl: NonEmptyVector[Field] = simpleOneFieldSchema
+  ): LegacyColumns.FieldForEntity = LegacyColumns.FieldForEntity(
+    field =
+      Field(s"unstruct_event_com_example_my_schema_${version.model}_${version.revision}_${version.addition}", Type.Struct(ddl), Nullable),
+    key        = SchemaKey("com.example", "mySchema", "jsonschema", version),
+    entityType = TabledEntity.UnstructEvent
+  )
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/ProcessingSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/ProcessingSpec.scala
@@ -37,10 +37,12 @@ class ProcessingSpec extends Specification with CatsEffect {
     Insert events to Bigquery and ack the events $e1
     Emit BadRows when there are badly formatted events $e2
     Write good batches and bad events when input contains both $e3
-    Alter the Bigquery table when the writer's protobuf Descriptor has missing columns - unstruct $e4_1
-    Alter the Bigquery table when the writer's protobuf Descriptor has missing columns - contexts $e4_2
-    Alter the Bigquery table when the writer's protobuf Descriptor has missing nested fields - unstruct $e4_3 
-    Alter the Bigquery table when the writer's protobuf Descriptor has missing nested fields - contexts $e4_4
+    Alter the Bigquery table when the writer's protobuf Descriptor has missing columns - unstruct $alter1
+    Alter the Bigquery table when the writer's protobuf Descriptor has missing columns - unstruct with legacy columns $alter1_legacy
+    Alter the Bigquery table when the writer's protobuf Descriptor has missing columns - contexts $alter2
+    Alter the Bigquery table when the writer's protobuf Descriptor has missing columns - contexts $alter2_legacy
+    Alter the Bigquery table when the writer's protobuf Descriptor has missing nested fields - unstruct $alter3 
+    Alter the Bigquery table when the writer's protobuf Descriptor has missing nested fields - contexts $alter4
     Skip altering the table when the writer's protobuf Descriptor has relevant self-describing entitiy columns $e5
     Emit BadRows when the WriterProvider reports a problem with the data $e6
     Recover when the WriterProvider reports a server-side schema mismatch $e7
@@ -109,7 +111,7 @@ class ProcessingSpec extends Specification with CatsEffect {
     }
   }
 
-  def e4_1 = {
+  def alter1_base(legacyColumns: Boolean) = {
     val unstructEvent: UnstructEvent = json"""
     {
       "schema": "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0",
@@ -121,11 +123,14 @@ class ProcessingSpec extends Specification with CatsEffect {
       }
     }
     """.as[UnstructEvent].fold(throw _, identity)
+    val expectedColumnName =
+      if (legacyColumns) "unstruct_event_com_snowplowanalytics_snowplow_media_ad_click_event_1_0_0"
+      else "unstruct_event_com_snowplowanalytics_snowplow_media_ad_click_event_1"
     val mocks = Mocks.default.copy(
       addColumnsResponse = MockEnvironment.Response.Success(
         FieldList.of(
           BQField.of(
-            "unstruct_event_com_snowplowanalytics_snowplow_media_ad_click_event_1",
+            expectedColumnName,
             StandardSQLTypeName.STRUCT,
             FieldList.of(BQField.of("percent_progress", StandardSQLTypeName.STRING))
           )
@@ -137,7 +142,8 @@ class ProcessingSpec extends Specification with CatsEffect {
         AtomicDescriptor.withWebPageAndAdClick
       )
     )
-    runTest(inputEvents(count = 1, good(unstructEvent)), mocks) { case (inputs, control) =>
+
+    runTest(inputEvents(count = 1, good(unstructEvent)), mocks, legacyColumns) { case (inputs, control) =>
       for {
         _ <- Processing.stream(control.environment).compile.drain
         state <- control.state.get
@@ -145,7 +151,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Vector(
           Action.CreatedTable,
           Action.OpenedWriter,
-          Action.AlterTableAddedColumns(Vector("unstruct_event_com_snowplowanalytics_snowplow_media_ad_click_event_1")),
+          Action.AlterTableAddedColumns(Vector(expectedColumnName)),
           Action.ClosedWriter,
           Action.OpenedWriter,
           Action.WroteRowsToBigQuery(2),
@@ -157,7 +163,10 @@ class ProcessingSpec extends Specification with CatsEffect {
     }
   }
 
-  def e4_2 = {
+  def alter1        = alter1_base(legacyColumns = false)
+  def alter1_legacy = alter1_base(legacyColumns = true)
+
+  def alter2_base(legacyColumns: Boolean) = {
     val data = json"""{ "percentProgress": 50 }"""
     val contexts = Contexts(
       List(
@@ -167,13 +176,16 @@ class ProcessingSpec extends Specification with CatsEffect {
         )
       )
     )
+    val expectedColumnName =
+      if (legacyColumns) "contexts_com_snowplowanalytics_snowplow_media_ad_click_event_1_0_0"
+      else "contexts_com_snowplowanalytics_snowplow_media_ad_click_event_1"
 
     val mocks = Mocks.default.copy(
       addColumnsResponse = MockEnvironment.Response.Success(
         FieldList.of(
           BQField
             .newBuilder(
-              "contexts_com_snowplowanalytics_snowplow_media_ad_click_event_1",
+              expectedColumnName,
               StandardSQLTypeName.STRUCT,
               FieldList.of(BQField.of("percent_progress", StandardSQLTypeName.STRING))
             )
@@ -187,7 +199,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         AtomicDescriptor.withAdClickContext
       )
     )
-    runTest(inputEvents(count = 1, good(contexts = contexts)), mocks) { case (inputs, control) =>
+    runTest(inputEvents(count = 1, good(contexts = contexts)), mocks, legacyColumns) { case (inputs, control) =>
       for {
         _ <- Processing.stream(control.environment).compile.drain
         state <- control.state.get
@@ -195,7 +207,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Vector(
           Action.CreatedTable,
           Action.OpenedWriter,
-          Action.AlterTableAddedColumns(Vector("contexts_com_snowplowanalytics_snowplow_media_ad_click_event_1")),
+          Action.AlterTableAddedColumns(Vector(expectedColumnName)),
           Action.ClosedWriter,
           Action.OpenedWriter,
           Action.WroteRowsToBigQuery(2),
@@ -207,7 +219,10 @@ class ProcessingSpec extends Specification with CatsEffect {
     }
   }
 
-  def e4_3 = {
+  def alter2        = alter2_base(legacyColumns = false)
+  def alter2_legacy = alter2_base(legacyColumns = true)
+
+  def alter3 = {
     val data = json"""{ "myInteger": 100 }"""
     val unstruct = UnstructEvent(
       Some(SelfDescribingData(SchemaKey.fromUri("iglu:test_vendor/test_name/jsonschema/1-0-1").toOption.get, data))
@@ -252,7 +267,7 @@ class ProcessingSpec extends Specification with CatsEffect {
     }
   }
 
-  def e4_4 = {
+  def alter4 = {
     val data     = json"""{ "myInteger": 100}"""
     val contexts = Contexts(List(SelfDescribingData(SchemaKey.fromUri("iglu:test_vendor/test_name/jsonschema/1-0-1").toOption.get, data)))
 
@@ -477,12 +492,13 @@ object ProcessingSpec {
 
   def runTest[A](
     toInputs: IO[List[TokenedEvents]],
-    mocks: Mocks = Mocks.default
+    mocks: Mocks           = Mocks.default,
+    legacyColumns: Boolean = false
   )(
     f: (List[TokenedEvents], MockEnvironment) => IO[A]
   ): IO[A] =
     toInputs.flatMap { inputs =>
-      MockEnvironment.build(inputs, mocks).use { control =>
+      MockEnvironment.build(inputs, mocks, legacyColumns).use { control =>
         f(inputs, control)
       }
     }

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
@@ -123,8 +123,9 @@ object KafkaConfigSpec {
       healthProbe = Config.HealthProbe(port = Port.fromInt(8000).get, unhealthyLatency = 5.minutes),
       webhook     = None
     ),
-    license     = AcceptedLicense(),
-    skipSchemas = List.empty
+    license       = AcceptedLicense(),
+    skipSchemas   = List.empty,
+    legacyColumns = false
   )
 
   private val extendedConfig = Config[KafkaSourceConfig, KafkaSinkConfig](
@@ -211,6 +212,7 @@ object KafkaConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/skipped2/jsonschema/1-0-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped3/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped4/jsonschema/*-*-*").get
-    )
+    ),
+    legacyColumns = false
   )
 }

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
@@ -125,7 +125,7 @@ object KafkaConfigSpec {
     ),
     license       = AcceptedLicense(),
     skipSchemas   = List.empty,
-    legacyColumns = false
+    legacyColumns = List.empty
   )
 
   private val extendedConfig = Config[KafkaSourceConfig, KafkaSinkConfig](
@@ -213,6 +213,9 @@ object KafkaConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/skipped3/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped4/jsonschema/*-*-*").get
     ),
-    legacyColumns = false
+    legacyColumns = List(
+      SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/1-*-*").get,
+      SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/2-*-*").get
+    )
   )
 }

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
@@ -121,8 +121,9 @@ object KinesisConfigSpec {
       healthProbe = Config.HealthProbe(port = Port.fromInt(8000).get, unhealthyLatency = 5.minutes),
       webhook     = None
     ),
-    license     = AcceptedLicense(),
-    skipSchemas = List.empty
+    license       = AcceptedLicense(),
+    skipSchemas   = List.empty,
+    legacyColumns = false
   )
 
   // workerIdentifer coming from "HOSTNAME" env variable set in BuildSettings
@@ -206,6 +207,7 @@ object KinesisConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/skipped2/jsonschema/1-0-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped3/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped4/jsonschema/*-*-*").get
-    )
+    ),
+    legacyColumns = false
   )
 }

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
@@ -123,7 +123,7 @@ object KinesisConfigSpec {
     ),
     license       = AcceptedLicense(),
     skipSchemas   = List.empty,
-    legacyColumns = false
+    legacyColumns = List.empty
   )
 
   // workerIdentifer coming from "HOSTNAME" env variable set in BuildSettings
@@ -208,6 +208,9 @@ object KinesisConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/skipped3/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped4/jsonschema/*-*-*").get
     ),
-    legacyColumns = false
+    legacyColumns = List(
+      SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/1-*-*").get,
+      SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/2-*-*").get
+    )
   )
 }

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
@@ -118,8 +118,9 @@ object PubsubConfigSpec {
       healthProbe = Config.HealthProbe(port = Port.fromInt(8000).get, unhealthyLatency = 5.minutes),
       webhook     = None
     ),
-    license     = AcceptedLicense(),
-    skipSchemas = List.empty
+    license       = AcceptedLicense(),
+    skipSchemas   = List.empty,
+    legacyColumns = false
   )
 
   private val extendedConfig = Config[PubsubSourceConfig, PubsubSinkConfig](
@@ -199,6 +200,7 @@ object PubsubConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/skipped2/jsonschema/1-0-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped3/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped4/jsonschema/*-*-*").get
-    )
+    ),
+    legacyColumns = false
   )
 }

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
@@ -120,7 +120,7 @@ object PubsubConfigSpec {
     ),
     license       = AcceptedLicense(),
     skipSchemas   = List.empty,
-    legacyColumns = false
+    legacyColumns = List.empty
   )
 
   private val extendedConfig = Config[PubsubSourceConfig, PubsubSinkConfig](
@@ -201,6 +201,9 @@ object PubsubConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/skipped3/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/skipped4/jsonschema/*-*-*").get
     ),
-    legacyColumns = false
+    legacyColumns = List(
+      SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/1-*-*").get,
+      SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/2-*-*").get
+    )
   )
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -44,7 +44,9 @@ object BuildSettings {
     Test / igluUris := Seq(
       // Iglu schemas used in unit tests
       "iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0",
-      "iglu:com.snowplowanalytics.snowplow.media/ad_click_event/jsonschema/1-0-0"
+      "iglu:com.snowplowanalytics.snowplow.media/ad_click_event/jsonschema/1-0-0",
+      "iglu:com.snowplowanalytics.snowplow.media/ad_break_end_event/jsonschema/1-0-0",
+      "iglu:com.snowplowanalytics.iglu/anything-a/jsonschema/1-0-0"
     )
   ) ++ commonSettings
 


### PR DESCRIPTION
In v1 of BigQuery Loader, we created a separate column for each _minor_ version of an Iglu schema.  Whereas in v2 of BigQuery Loader, schemas with the same major version share the same column.  This might make it hard for users to upgrade from version 1 to version 2; and so users might miss out on all the other lovely stuff we added in v2.

This PR adds back in support for the legacy style of columns.  It is enabled by setting `legacyColumns = [...]` in the config file, where the config value lists schema keys to treat as legacy.