### PR TITLE
Bump common-streams to 0.8.2-M1 and iglu-scala-client to 4.0.0

### DIFF
--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
@@ -111,8 +111,8 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       val expectedStruct = Type.Struct(
         NonEmptyVector.of(
           Field("col_camel", Type.Json, Required, Set("colCamel")),
-          Field("col_snake", Type.Json, Required, Set("col_snake")),
-          Field("col_other", Type.Long, Nullable, Set("col_other"))
+          Field("col_other", Type.Long, Nullable, Set("col_other")),
+          Field("col_snake", Type.Json, Required, Set("col_snake"))
         )
       )
 
@@ -283,8 +283,8 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
       val expectedStruct = Type.Struct(
         NonEmptyVector.of(
           Field("col_camel", Type.Json, Required, Set("colCamel")),
-          Field("col_snake", Type.Json, Required, Set("col_snake")),
-          Field("col_other", Type.Long, Nullable, Set("col_other"))
+          Field("col_other", Type.Long, Nullable, Set("col_other")),
+          Field("col_snake", Type.Json, Required, Set("col_snake"))
         )
       )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,8 +29,8 @@ object Dependencies {
     val bigquery        = "2.34.2"
 
     // Snowplow
-    val streams    = "0.8.0-M6"
-    val igluClient = "3.1.0"
+    val streams    = "0.8.2-M1"
+    val igluClient = "4.0.0"
 
     // tests
     val specs2           = "4.20.0"


### PR DESCRIPTION
For this app, the most significant changes are:

- common-streams has a big change in how it preserves the order of struct fields: snowplow-incubator/common-streams#98 This should not impact how BigQuery loader works. But I highlight here because of the potential risk if we got something wrong.
- iglu-scala-client now treats both 403 and 404 as NotFound when listing a series of schemas from the Iglu repos: snowplow/iglu-scala-client#260