### PR TITLE
Add e2e_latency_millis metric

### DIFF
--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -43,6 +43,7 @@ object MockEnvironment {
     case class AddedGoodCountMetric(count: Long) extends Action
     case class AddedBadCountMetric(count: Long) extends Action
     case class SetLatencyMetric(latency: FiniteDuration) extends Action
+    case class SetE2ELatencyMetric(e2eLatency: FiniteDuration) extends Action
     case class BecameUnhealthy(service: RuntimeService) extends Action
     case class BecameHealthy(service: RuntimeService) extends Action
   }
@@ -236,6 +237,9 @@ object MockEnvironment {
 
     def setLatency(latency: FiniteDuration): IO[Unit] =
       ref.update(_ :+ SetLatencyMetric(latency))
+
+    def setE2ELatency(e2eLatency: FiniteDuration): IO[Unit] =
+      ref.update(_ :+ SetE2ELatencyMetric(e2eLatency))
 
     def report: Stream[IO, Nothing] = Stream.never[IO]
   }


### PR DESCRIPTION
This PR adds a new metric `e2e_latency_millis` which measures the difference between an event's `collector_tstamp` and when it was written to BigQuery.

The metric is emitted to statsd only on minutes in which some events are written to BigQuery, i.e. the end of a window.  In other minutes (mid-window) the metric is not defined and not emitted to statsd.

The metric measures the worst-case latency for a window, i.e. latency for the earliest seen `collector_tstamp`.

ref:PDP-1648
