### PR TITLE
Loader should handle BigQuery exceptions for an invalid request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Build artifacts
         run: |
           sbt 'project mutator' assembly
@@ -54,6 +56,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Get current version
         id: ver

--- a/.github/workflows/lacework.yml
+++ b/.github/workflows/lacework.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Get current version
         id: ver
         run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Run tests
         run: sbt test


### PR DESCRIPTION
BigQuery occasionally returns a response with a 400 response code. Before this PR, it would cause the loader to crash and exit. After this PR, we break the original request into smaller requests and try to load each event individually. This allows valid events in the batch to get loaded, while the invalid requests eventually become failed inserts.

Known examples of when this needed: When the table is partitioned by `derived_tstamp`, and an event has a `derived_tstamp` more than 1825 days in the past.