### PR TITLE
Add legacyColumnMode configuration

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -111,6 +111,10 @@
     "iglu:com.acme/legacy/jsonschema/2-*-*"
   ]
 
+  # -- Whether the loader should load to legacy columns irrespective of `legacyColumns` configuration.
+  # -- Change to `true` so events go to the legacy columns.
+  "legacyColumnMode": false
+
   # -- Whether the loader should crash and exit if it fails to resolve an Iglu Schema.
   # -- We recommend `true` because Snowplow enriched events have already passed validation, so a missing schema normally
   # -- indicates an error that needs addressing.

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -145,6 +145,10 @@
     "iglu:com.acme/legacy/jsonschema/2-*-*"
   ]
 
+  # -- Whether the loader should load to legacy columns irrespective of `legacyColumns` configuration.
+  # -- Change to `true` so events go to the legacy columns.
+  "legacyColumnMode": false
+
   # -- Whether the loader should crash and exit if it fails to resolve an Iglu Schema.
   # -- We recommend `true` because Snowplow enriched events have already passed validation, so a missing schema normally
   # -- indicates an error that needs addressing.

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -117,6 +117,10 @@
     "iglu:com.acme/legacy/jsonschema/2-*-*"
   ]
 
+  # -- Whether the loader should load to legacy columns irrespective of `legacyColumns` configuration.
+  # -- Change to `true` so events go to the legacy columns.
+  "legacyColumnMode": false
+
   # -- Whether the loader should crash and exit if it fails to resolve an Iglu Schema.
   # -- We recommend `true` because Snowplow enriched events have already passed validation, so a missing schema normally
   # -- indicates an error that needs addressing.

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -42,6 +42,7 @@
 
   "skipSchemas": []
   "legacyColumns": []
+  "legacyColumnMode": false
   "exitOnMissingIgluSchema": true
 
   "http": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Config.scala
@@ -32,6 +32,7 @@ case class Config[+Source, +Sink](
   license: AcceptedLicense,
   skipSchemas: List[SchemaCriterion],
   legacyColumns: List[SchemaCriterion],
+  legacyColumnMode: Boolean,
   exitOnMissingIgluSchema: Boolean,
   http: Config.Http
 )

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
@@ -36,6 +36,7 @@ case class Environment[F[_]](
   badRowMaxSize: Int,
   schemasToSkip: List[SchemaCriterion],
   legacyColumns: List[SchemaCriterion],
+  legacyColumnMode: Boolean,
   exitOnMissingIgluSchema: Boolean
 )
 
@@ -79,6 +80,7 @@ object Environment {
       badRowMaxSize           = config.main.output.bad.maxRecordSize,
       schemasToSkip           = config.main.skipSchemas,
       legacyColumns           = config.main.legacyColumns,
+      legacyColumnMode        = config.main.legacyColumnMode,
       exitOnMissingIgluSchema = config.main.exitOnMissingIgluSchema
     )
 

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumns.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumns.scala
@@ -105,7 +105,8 @@ object LegacyColumns {
   def resolveTypes[F[_]: Sync: RegistryLookup](
     resolver: Resolver[F],
     entities: Map[TabledEntity, Set[SchemaSubVersion]],
-    matchCriteria: List[SchemaCriterion]
+    matchCriteria: List[SchemaCriterion],
+    legacyColumnMode: Boolean
   ): F[Result] =
     entities.toVector
       .flatMap { case (tabledEntity, subVersions) =>
@@ -114,7 +115,8 @@ object LegacyColumns {
             (tabledEntity.entityType, TabledEntity.toSchemaKey(tabledEntity, subVersion))
           }
           .filter { case (_, schemaKey) =>
-            matchCriteria.exists(_.matches(schemaKey))
+            if (legacyColumnMode) true
+            else matchCriteria.exists(_.matches(schemaKey))
           }
       }
       .traverse { case (entityType, schemaKey) =>

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/Processing.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/Processing.scala
@@ -175,7 +175,7 @@ object Processing {
       )
     }
 
-  private[processing] def resolveV2NonAtomicFields[F[_]: Async: RegistryLookup](
+  private def resolveV2NonAtomicFields[F[_]: Async: RegistryLookup](
     env: Environment[F],
     entities: Map[TabledEntity, Set[SchemaSubVersion]]
   ): F[Result] =

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -64,7 +64,8 @@ object MockEnvironment {
   def build(
     inputs: List[TokenedEvents],
     mocks: Mocks,
-    legacyColumns: List[SchemaCriterion]
+    legacyColumns: List[SchemaCriterion],
+    legacyColumnMode: Boolean
   ): Resource[IO, MockEnvironment] =
     for {
       state <- Resource.eval(Ref[IO].of(Vector.empty[Action]))
@@ -90,6 +91,7 @@ object MockEnvironment {
         badRowMaxSize           = 1000000,
         schemasToSkip           = List.empty,
         legacyColumns           = legacyColumns,
+        legacyColumnMode        = legacyColumnMode,
         exitOnMissingIgluSchema = false
       )
       MockEnvironment(state, env)

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -24,11 +24,10 @@ import com.snowplowanalytics.snowplow.runtime.processing.Coldswap
 import com.snowplowanalytics.snowplow.sources.{EventProcessingConfig, EventProcessor, SourceAndAck, TokenedEvents}
 import com.snowplowanalytics.snowplow.sinks.Sink
 import com.snowplowanalytics.snowplow.bigquery.processing.{BigQueryRetrying, TableManager, Writer}
-import com.snowplowanalytics.snowplow.bigquery.MockEnvironment.Action
+import com.snowplowanalytics.snowplow.bigquery.MockEnvironment.State
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-case class State(actions: Vector[Action], writtenToBQ: Iterable[Map[String, AnyRef]])
 case class MockEnvironment(state: Ref[IO, State], environment: Environment[IO])
 
 object MockEnvironment {
@@ -50,6 +49,8 @@ object MockEnvironment {
     case class BecameHealthy(service: RuntimeService) extends Action
   }
   import Action._
+
+  case class State(actions: Vector[Action], writtenToBQ: Iterable[Map[String, AnyRef]])
 
   /**
    * Build a mock environment for testing

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
@@ -255,6 +255,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
     LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, legacyColumnMode = true).map {
       case LegacyColumns.Result(fields, failures) =>
         (failures must beEmpty) and
+          (fields must haveSize(1)) and
           (fields must contain(expected))
     }
 
@@ -476,6 +477,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
     LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, legacyColumnMode = true).map {
       case LegacyColumns.Result(fields, failures) =>
         (failures must beEmpty) and
+          (fields must haveSize(1)) and
           (fields must contain(expected))
     }
 

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/LegacyColumnsResolveSpec.scala
@@ -75,7 +75,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -128,7 +128,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(2)) and
         (fields must contain(expected100)) and
@@ -160,7 +160,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("com.snowplowanalytics.snowplow.media", "ad_break_end_event", "jsonschema", 1))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -190,7 +190,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("com.snowplowanalytics.iglu", "anything-a", "jsonschema", 1))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -209,7 +209,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
     // non-matching schema criteria:
     val legacyCriteria = List(SchemaCriterion("myvendor", "different", "jsonschema", 7))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must beEmpty)
     }
@@ -245,7 +245,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -302,7 +302,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(2)) and
         (fields must contain(expected100)) and
@@ -334,7 +334,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("com.snowplowanalytics.snowplow.media", "ad_break_end_event", "jsonschema", 1))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -368,7 +368,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("com.snowplowanalytics.iglu", "anything-a", "jsonschema", 1))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(1)) and
         (fields must contain(expected))
@@ -387,7 +387,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
     // non-matching schema criteria
     val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 4))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must beEmpty)
     }
@@ -406,7 +406,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (failures must beEmpty) and
         (fields must haveSize(2)) and
         (fields.map(_.entityType) must contain(allOf[TabledEntity.EntityType](TabledEntity.UnstructEvent, TabledEntity.Context)))
@@ -426,7 +426,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("myvendor", "myschema", "jsonschema", 7))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (fields must beEmpty) and
         (failures must haveSize(1)) and
         (failures.head must beLike { case failure: LegacyColumns.ColumnFailure =>
@@ -449,7 +449,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
 
     val legacyCriteria = List(SchemaCriterion("myvendor", "invalid_syntax", "jsonschema", 1))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (fields must beEmpty) and
         (failures must haveSize(1)) and
         (failures.head must beLike { case failure: LegacyColumns.ColumnFailure =>
@@ -471,7 +471,7 @@ class LegacyColumnsResolveSpec extends Specification with CatsEffect {
     // non-matching crieria
     val legacyCriteria = List(SchemaCriterion("other.vendor", "myschema", "jsonschema", 7))
 
-    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria).map { case LegacyColumns.Result(fields, failures) =>
+    LegacyColumns.resolveTypes(embeddedResolver, input, legacyCriteria, false).map { case LegacyColumns.Result(fields, failures) =>
       (fields must beEmpty) and
         (failures must beEmpty)
     }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/ProcessingSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/processing/ProcessingSpec.scala
@@ -28,6 +28,7 @@ import com.snowplowanalytics.snowplow.sources.TokenedEvents
 import scala.concurrent.duration.DurationLong
 
 import java.time.Instant
+import java.util.UUID
 
 class ProcessingSpec extends Specification with CatsEffect {
   import ProcessingSpec._
@@ -53,6 +54,7 @@ class ProcessingSpec extends Specification with CatsEffect {
     Mark app as unhealthy when writing to the Writer fails with runtime exception $e10
     Emit BadRows for an unknown schema, if exitOnMissingIgluSchema is false $e11 $e11Legacy
     Crash and exit for an unknown schema, if exitOnMissingIgluSchema is true $e12 $e12Legacy
+    use legacy columns for all fields when legacyColumnMode is enabled $e13
   """
 
   def e1 = {
@@ -68,7 +70,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Vector(
           Action.CreatedTable,
           Action.OpenedWriter,
-          Action.WroteRowsToBigQuery(4),
+          Action.WroteNRowsToBigQuery(4),
           Action.SetE2ELatencyMetric(42123.millis),
           Action.AddedGoodCountMetric(4),
           Action.AddedBadCountMetric(0),
@@ -115,7 +117,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Vector(
           Action.CreatedTable,
           Action.OpenedWriter,
-          Action.WroteRowsToBigQuery(6),
+          Action.WroteNRowsToBigQuery(6),
           Action.SetE2ELatencyMetric(52123.millis),
           Action.SentToBad(6),
           Action.AddedGoodCountMetric(6),
@@ -147,7 +149,7 @@ class ProcessingSpec extends Specification with CatsEffect {
     }
     """.as[UnstructEvent].fold(throw _, identity)
     val expectedColumnName =
-      if (legacyColumnMode) "unstruct_event_com_snowplowanalytics_snowplow_media_ad_click_event_1"
+      if (legacyColumnMode) "unstruct_event_com_snowplowanalytics_snowplow_media_ad_click_event_1_0_0"
       else if (legacyColumns) "unstruct_event_com_snowplowanalytics_snowplow_media_ad_click_event_1_0_0"
       else "unstruct_event_com_snowplowanalytics_snowplow_media_ad_click_event_1"
     val mocks = Mocks.default.copy(
@@ -184,7 +186,7 @@ class ProcessingSpec extends Specification with CatsEffect {
             Action.AlterTableAddedColumns(Vector(expectedColumnName)),
             Action.ClosedWriter,
             Action.OpenedWriter,
-            Action.WroteRowsToBigQuery(2),
+            Action.WroteNRowsToBigQuery(2),
             Action.SetE2ELatencyMetric(2123.millis),
             Action.AddedGoodCountMetric(2),
             Action.AddedBadCountMetric(0),
@@ -218,7 +220,7 @@ class ProcessingSpec extends Specification with CatsEffect {
       )
     )
     val expectedColumnName =
-      if (legacyColumnMode) "contexts_com_snowplowanalytics_snowplow_media_ad_click_event_1"
+      if (legacyColumnMode) "contexts_com_snowplowanalytics_snowplow_media_ad_click_event_1_0_0"
       else if (legacyColumns) "contexts_com_snowplowanalytics_snowplow_media_ad_click_event_1_0_0"
       else "contexts_com_snowplowanalytics_snowplow_media_ad_click_event_1"
 
@@ -260,7 +262,7 @@ class ProcessingSpec extends Specification with CatsEffect {
               Action.AlterTableAddedColumns(Vector(expectedColumnName)),
               Action.ClosedWriter,
               Action.OpenedWriter,
-              Action.WroteRowsToBigQuery(2),
+              Action.WroteNRowsToBigQuery(2),
               Action.SetE2ELatencyMetric(43123.millis),
               Action.AddedGoodCountMetric(2),
               Action.AddedBadCountMetric(0),
@@ -317,7 +319,7 @@ class ProcessingSpec extends Specification with CatsEffect {
             Action.AlterTableAddedColumns(Vector("unstruct_event_test_vendor_test_name_1")),
             Action.ClosedWriter,
             Action.OpenedWriter,
-            Action.WroteRowsToBigQuery(2),
+            Action.WroteNRowsToBigQuery(2),
             Action.SetE2ELatencyMetric(43123.millis),
             Action.AddedGoodCountMetric(2),
             Action.AddedBadCountMetric(0),
@@ -370,7 +372,7 @@ class ProcessingSpec extends Specification with CatsEffect {
             Action.AlterTableAddedColumns(Vector("contexts_test_vendor_test_name_1")),
             Action.ClosedWriter,
             Action.OpenedWriter,
-            Action.WroteRowsToBigQuery(2),
+            Action.WroteNRowsToBigQuery(2),
             Action.SetE2ELatencyMetric(43123.millis),
             Action.AddedGoodCountMetric(2),
             Action.AddedBadCountMetric(0),
@@ -405,7 +407,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Vector(
           Action.CreatedTable,
           Action.OpenedWriter,
-          Action.WroteRowsToBigQuery(2),
+          Action.WroteNRowsToBigQuery(2),
           Action.SetE2ELatencyMetric(52123.millis),
           Action.AddedGoodCountMetric(2),
           Action.AddedBadCountMetric(0),
@@ -435,7 +437,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Vector(
           Action.CreatedTable,
           Action.OpenedWriter,
-          Action.WroteRowsToBigQuery(1),
+          Action.WroteNRowsToBigQuery(1),
           Action.SetE2ELatencyMetric(52123.millis),
           Action.SentToBad(1),
           Action.AddedGoodCountMetric(1),
@@ -470,7 +472,7 @@ class ProcessingSpec extends Specification with CatsEffect {
           Action.OpenedWriter,
           Action.ClosedWriter,
           Action.OpenedWriter,
-          Action.WroteRowsToBigQuery(2),
+          Action.WroteNRowsToBigQuery(2),
           Action.SetE2ELatencyMetric(54123.millis),
           Action.AddedGoodCountMetric(2),
           Action.AddedBadCountMetric(0),
@@ -504,7 +506,7 @@ class ProcessingSpec extends Specification with CatsEffect {
           Action.OpenedWriter,
           Action.ClosedWriter,
           Action.OpenedWriter,
-          Action.WroteRowsToBigQuery(2),
+          Action.WroteNRowsToBigQuery(2),
           Action.SetE2ELatencyMetric(42123.millis),
           Action.AddedGoodCountMetric(2),
           Action.AddedBadCountMetric(0),
@@ -584,7 +586,7 @@ class ProcessingSpec extends Specification with CatsEffect {
             Vector(
               Action.CreatedTable,
               Action.OpenedWriter,
-              Action.WroteRowsToBigQuery(1),
+              Action.WroteNRowsToBigQuery(1),
               Action.SetE2ELatencyMetric(42123.millis),
               Action.SentToBad(1),
               Action.AddedGoodCountMetric(1),
@@ -635,6 +637,33 @@ class ProcessingSpec extends Specification with CatsEffect {
   def e12       = e12Base(legacyColumns = false)
   def e12Legacy = e12Base(legacyColumns = true)
 
+  def e13 = {
+    val processTime = Instant.parse("2023-10-24T10:00:42.123Z")
+
+    val eventID    = UUID.randomUUID()
+    val vCollector = "1.0.0"
+    val vEtl       = "2.0.0"
+    val source = goodOne(
+      optEventId    = Option(IO(eventID)),
+      optVCollector = Option(vCollector),
+      optVEtl       = Option(vEtl)
+    )
+
+    val io = runTest(inputEvents(count = 1, source), legacyColumnMode = true, recordRows = true) { case (inputs, control) =>
+      for {
+        _ <- IO.sleep(processTime.toEpochMilli.millis)
+        _ <- Processing.stream(control.environment).compile.drain
+        state <- control.state.get
+      } yield {
+        val rows = state.collect { case act: Action.WroteRowsToBigQuery => act }.head.rows
+        (rows.size shouldEqual inputs.head.events.size) and
+          (rows.head.get("event_id") should beEqualTo(Option(eventID.toString))) and
+          (rows.head.get("v_collector") should beEqualTo(Option(vCollector))) and
+          (rows.head.get("v_etl") should beEqualTo(Option(vEtl)))
+      }
+    }
+    TestControl.executeEmbed(io)
+  }
 }
 
 object ProcessingSpec {
@@ -643,12 +672,13 @@ object ProcessingSpec {
     toInputs: IO[List[TokenedEvents]],
     mocks: Mocks                          = Mocks.default,
     legacyCriteria: List[SchemaCriterion] = Nil,
-    legacyColumnMode: Boolean             = false
+    legacyColumnMode: Boolean             = false,
+    recordRows: Boolean                   = false
   )(
     f: (List[TokenedEvents], MockEnvironment) => IO[A]
   ): IO[A] =
     toInputs.flatMap { inputs =>
-      MockEnvironment.build(inputs, mocks, legacyCriteria, legacyColumnMode).use { control =>
+      MockEnvironment.build(inputs, mocks, legacyCriteria, legacyColumnMode, recordRows).use { control =>
         f(inputs, control)
       }
     }
@@ -660,6 +690,25 @@ object ProcessingSpec {
       .take(count)
       .compile
       .toList
+
+  def goodOne(
+    ue: UnstructEvent                       = UnstructEvent(None),
+    contexts: Contexts                      = Contexts(List.empty),
+    optEventId: Option[IO[UUID]]            = None,
+    optCollectorTstamp: Option[IO[Instant]] = None,
+    optVCollector: Option[String]           = None,
+    optVEtl: Option[String]                 = None
+  ): IO[TokenedEvents] =
+    for {
+      ack <- IO.unique
+      eventId <- optEventId.fold(IO.randomUUID)(identity)
+      collectorTstamp <- optCollectorTstamp.fold(IO.realTimeInstant)(identity)
+      vCollector = optVCollector.fold("0.0.0")(identity)
+      vEtl       = optVEtl.fold("0.0.0")(identity)
+    } yield {
+      val e = Event.minimal(eventId, collectorTstamp, vCollector, vEtl).copy(unstruct_event = ue).copy(contexts = contexts)
+      TokenedEvents(Chunk(ByteBuffer.wrap(e.toTsv.getBytes(StandardCharsets.UTF_8))), ack)
+    }
 
   def good(
     ue: UnstructEvent                   = UnstructEvent(None),

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
@@ -124,6 +124,7 @@ object KafkaConfigSpec {
     license                 = AcceptedLicense(),
     skipSchemas             = List.empty,
     legacyColumns           = List.empty,
+    legacyColumnMode        = false,
     exitOnMissingIgluSchema = true,
     http                    = Config.Http(HttpClient.Config(4))
   )
@@ -218,6 +219,7 @@ object KafkaConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/2-*-*").get
     ),
+    legacyColumnMode        = false,
     exitOnMissingIgluSchema = true,
     http                    = Config.Http(HttpClient.Config(4))
   )

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
@@ -124,6 +124,7 @@ object KinesisConfigSpec {
     license                 = AcceptedLicense(),
     skipSchemas             = List.empty,
     legacyColumns           = List.empty,
+    legacyColumnMode        = false,
     exitOnMissingIgluSchema = true,
     http                    = Config.Http(HttpClient.Config(4))
   )
@@ -216,6 +217,7 @@ object KinesisConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/2-*-*").get
     ),
+    legacyColumnMode        = false,
     exitOnMissingIgluSchema = true,
     http                    = Config.Http(HttpClient.Config(4))
   )

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
@@ -118,6 +118,7 @@ object PubsubConfigSpec {
     license                 = AcceptedLicense(),
     skipSchemas             = List.empty,
     legacyColumns           = List.empty,
+    legacyColumnMode        = false,
     exitOnMissingIgluSchema = true,
     http                    = Config.Http(HttpClient.Config(4))
   )
@@ -204,6 +205,7 @@ object PubsubConfigSpec {
       SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/1-*-*").get,
       SchemaCriterion.parse("iglu:com.acme/legacy/jsonschema/2-*-*").get
     ),
+    legacyColumnMode        = false,
     exitOnMissingIgluSchema = true,
     http                    = Config.Http(HttpClient.Config(4))
   )


### PR DESCRIPTION
This commit introduces a new feature flag `legacyColumnMode` , changing loading behavior such that all events are loaded to legacy columns regardless of `legacyColumns` configuration. Set it to true to enable legacy behavior.

ref: PDP-1489