### PR TITLE
Open several writers to increase BigQuery throughput

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/Environment.scala
@@ -28,7 +28,7 @@ case class Environment[F[_]](
   resolver: Resolver[F],
   httpClient: Client[F],
   tableManager: TableManager.WithHandledErrors[F],
-  writer: Writer.Provider[F],
+  writers: Vector[Writer.Provider[F]],
   metrics: Metrics[F],
   appHealth: AppHealth.Interface[F, Alert, RuntimeService],
   alterTableWaitPolicy: RetryPolicy[F],
@@ -64,7 +64,9 @@ object Environment {
       tableManager <- Resource.eval(TableManager.make(config.main.output.good, creds))
       tableManagerWrapped <- Resource.eval(TableManager.withHandledErrors(tableManager, config.main.retries, appHealth))
       writerBuilder <- Writer.builder(config.main.output.good, creds)
-      writerProvider <- Writer.provider(writerBuilder, config.main.retries, appHealth)
+      writerProviders <- Vector.range(0, config.main.batching.writeBatchConcurrency).traverse { _ =>
+                           Writer.provider(writerBuilder, config.main.retries, appHealth)
+                         }
     } yield Environment(
       appInfo                 = appInfo,
       source                  = sourceAndAck,
@@ -72,7 +74,7 @@ object Environment {
       resolver                = resolver,
       httpClient              = httpClient,
       tableManager            = tableManagerWrapped,
-      writer                  = writerProvider,
+      writers                 = writerProviders,
       metrics                 = metrics,
       appHealth               = appHealth,
       alterTableWaitPolicy    = BigQueryRetrying.policyForAlterTableWait[F](config.main.retries),

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -82,7 +82,7 @@ object MockEnvironment {
         resolver             = Resolver[IO](Nil, None),
         httpClient           = testHttpClient,
         tableManager         = testTableManager(mocks.addColumnsResponse, state),
-        writer               = writerColdswap,
+        writers              = Vector(writerColdswap),
         metrics              = testMetrics(state),
         appHealth            = testAppHealth(state),
         alterTableWaitPolicy = BigQueryRetrying.policyForAlterTableWait[IO](retriesConfig),


### PR DESCRIPTION
Before this PR, the loader opened a single `JsonStreamWriter`, and therefore a single stream (single bidirectional RPC). We observed the loader seems to hit a bottleneck where it cannot write into BigQuery quickly enough.

After this PR, the loader opens a configurable number of streams, which is expected to prevent the bottleneck.

This implementation closely follows a similar change we made in the snowflake loader: snowplow-incubator/snowflake-loader#57