### PR TITLE
Decrease default batching.maxBytes to 10 MB

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -55,7 +55,7 @@
   "batching": {
 
     # -- Events are emitted to BigQuery when the batch reaches this size in bytes
-    "maxBytes": 16000000
+    "maxBytes": 10000000
 
     # -- Events are emitted to BigQuery for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -89,7 +89,7 @@
   "batching": {
 
     # -- Events are emitted to BigQuery when the batch reaches this size in bytes
-    "maxBytes": 16000000
+    "maxBytes": 10000000
 
     # -- Events are emitted to BigQuery for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -61,7 +61,7 @@
   "batching": {
 
     # -- Events are emitted to BigQuery when the batch reaches this size in bytes
-    "maxBytes": 16000000
+    "maxBytes": 10000000
 
     # -- Events are emitted to BigQuery for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -19,7 +19,7 @@
   }
 
   "batching": {
-    "maxBytes": 16000000
+    "maxBytes": 10000000
     "maxDelay": "1 second"
     "writeBatchConcurrency":  3
   }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -87,7 +87,7 @@ object MockEnvironment {
         appHealth            = testAppHealth(state),
         alterTableWaitPolicy = BigQueryRetrying.policyForAlterTableWait[IO](retriesConfig),
         batching = Config.Batching(
-          maxBytes              = 16000000,
+          maxBytes              = 10000000,
           maxDelay              = 10.seconds,
           writeBatchConcurrency = 1
         ),

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
@@ -93,7 +93,7 @@ object KafkaConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes              = 16000000,
+      maxBytes              = 10000000,
       maxDelay              = 1.second,
       writeBatchConcurrency = 3
     ),
@@ -166,7 +166,7 @@ object KafkaConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes              = 16000000,
+      maxBytes              = 10000000,
       maxDelay              = 1.second,
       writeBatchConcurrency = 1
     ),

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
@@ -93,7 +93,7 @@ object KinesisConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes              = 16000000,
+      maxBytes              = 10000000,
       maxDelay              = 1.second,
       writeBatchConcurrency = 3
     ),
@@ -164,7 +164,7 @@ object KinesisConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes              = 16000000,
+      maxBytes              = 10000000,
       maxDelay              = 1.second,
       writeBatchConcurrency = 1
     ),

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
@@ -87,7 +87,7 @@ object PubsubConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes              = 16000000,
+      maxBytes              = 10000000,
       maxDelay              = 1.second,
       writeBatchConcurrency = 3
     ),
@@ -152,7 +152,7 @@ object PubsubConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes              = 16000000,
+      maxBytes              = 10000000,
       maxDelay              = 1.second,
       writeBatchConcurrency = 1
     ),


### PR DESCRIPTION
Current default value causes `too large request` error.