### PR TITLE
Bump common-streams to 0.11.0

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -11,6 +11,10 @@
     # -- kafka bootstrap servers
     "bootstrapServers": "localhost:9092"
 
+    # -- How frequently to commit our progress back to kafka. By increasing this value,
+    # -- we decrease the number of requests made to the kafka broker
+    debounceCommitOffsets: "10 seconds"
+
     # -- Any valid Kafka consumer config options
     consumerConf: {
       "group.id": "snowplow-bigquery-loader"

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -48,6 +48,10 @@
       "minBackoff": "100 millis"
       "maxBackoff": "1 second"
     }
+
+    ## -- How frequently to checkpoint our progress to the DynamoDB table. By increasing this value,
+    ## -- we can decrease the write-throughput requirements of the DynamoDB table
+    debounceCheckpoints: "10 seconds"
   }
 
   "output": {

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
@@ -59,8 +59,9 @@ class KafkaConfigSpec extends Specification with CatsEffect {
 object KafkaConfigSpec {
   private val minimalConfig = Config[KafkaSourceConfig, KafkaSinkConfig](
     input = KafkaSourceConfig(
-      topicName        = "sp-dev-enriched",
-      bootstrapServers = "localhost:9092",
+      topicName             = "sp-dev-enriched",
+      bootstrapServers      = "localhost:9092",
+      debounceCommitOffsets = 10.seconds,
       consumerConf = Map(
         "group.id" -> "snowplow-bigquery-loader",
         "allow.auto.create.topics" -> "false",
@@ -131,8 +132,9 @@ object KafkaConfigSpec {
 
   private val extendedConfig = Config[KafkaSourceConfig, KafkaSinkConfig](
     input = KafkaSourceConfig(
-      topicName        = "sp-dev-enriched",
-      bootstrapServers = "localhost:9092",
+      topicName             = "sp-dev-enriched",
+      bootstrapServers      = "localhost:9092",
+      debounceCommitOffsets = 10.seconds,
       consumerConf = Map(
         "group.id" -> "snowplow-bigquery-loader",
         "enable.auto.commit" -> "false",

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
@@ -71,7 +71,8 @@ object KinesisConfigSpec {
       cloudwatchCustomEndpoint         = None,
       leaseDuration                    = 10.seconds,
       maxLeasesToStealAtOneTimeFactor  = BigDecimal("2.0"),
-      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second)
+      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second),
+      debounceCheckpoints              = 10.seconds
     ),
     output = Config.Output(
       good = Config.BigQuery(
@@ -142,7 +143,8 @@ object KinesisConfigSpec {
       cloudwatchCustomEndpoint         = None,
       leaseDuration                    = 10.seconds,
       maxLeasesToStealAtOneTimeFactor  = BigDecimal("2.0"),
-      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second)
+      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second),
+      debounceCheckpoints              = 10.seconds
     ),
     output = Config.Output(
       good = Config.BigQuery(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,14 +22,14 @@ object Dependencies {
 
     // java
     val slf4j           = "2.0.12"
-    val azureSdk        = "1.11.4"
+    val azureSdk        = "1.15.1"
     val sentry          = "6.25.2"
-    val awsSdk2         = "2.29.0"
-    val bigqueryStorage = "2.47.0"
-    val bigquery        = "2.34.2"
+    val awsSdk2         = "2.30.17"
+    val bigqueryStorage = "3.11.2"
+    val bigquery        = "2.47.0"
 
     // Snowplow
-    val streams    = "0.10.0"
+    val streams    = "0.11.0"
     val igluClient = "4.0.0"
 
     // tests


### PR DESCRIPTION
common-streams 0.11.0 brings:

*  Debounce how often we checkpoint progress. It allows to decrease the write-throughput requirements of the DynamoDB table for kinesis source and decrease the number of requests made to the kafka broker for kafka source. https://github.com/snowplow-incubator/common-streams/pull/109
* Prefetch from pubsub source when parallelPullCount is 1. This means the pubsub source behaves more consistently across different parallelisms, and more similar to the other sources. https://github.com/snowplow-incubator/common-streams/pull/110
* Dependencies upgrades https://github.com/snowplow-incubator/common-streams/pull/112