### PR TITLE
Add parallelism to parseBytes and transform

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -61,7 +61,20 @@
     "maxDelay": "1 second"
 
     # -- How many batches can we send simultaneously over the network to BigQuery.
-    "writeBatchConcurrency":  1
+    "writeBatchConcurrency":  2
+  }
+
+  "cpuParallelism" {
+
+    # - Controls how many batches of bytes we can parse into enriched events simultaneously.
+    # -- E.g. If there are 2 cores, and parseBytesFactor = 0.1, then only one batch gets processed at a time.
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "parseBytesFactor": 0.1
+
+    # - Controls how many batches of enriched events we can transform into BigQuery format simultaneously.
+    # -- E.g. If there are 4 cores, and parseBytesFactor = 0.75, then 3 batches gets processed in parallel.
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "transformFactor": 0.75
   }
 
   # Retry configuration for BigQuery operation failures

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -95,7 +95,20 @@
     "maxDelay": "1 second"
 
     # -- How many batches can we send simultaneously over the network to BigQuery.
-    "writeBatchConcurrency":  1
+    "writeBatchConcurrency":  2
+  }
+
+  "cpuParallelism" {
+
+    # - Controls how many batches of bytes we can parse into enriched events simultaneously.
+    # -- E.g. If there are 2 cores, and parseBytesFactor = 0.1, then only one batch gets processed at a time.
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "parseBytesFactor": 0.1
+
+    # - Controls how many batches of enriched events we can transform into BigQuery format simultaneously.
+    # -- E.g. If there are 4 cores, and parseBytesFactor = 0.75, then 3 batches gets processed in parallel.
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "transformFactor": 0.75
   }
 
   # Retry configuration for BigQuery operation failures

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -67,7 +67,20 @@
     "maxDelay": "1 second"
 
     # -- How many batches can we send simultaneously over the network to BigQuery.
-    "writeBatchConcurrency":  1
+    "writeBatchConcurrency":  2
+  }
+
+  "cpuParallelism" {
+
+    # - Controls how many batches of bytes we can parse into enriched events simultaneously.
+    # -- E.g. If there are 2 cores, and parseBytesFactor = 0.1, then only one batch gets processed at a time.
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "parseBytesFactor": 0.1
+
+    # - Controls how many batches of enriched events we can transform into BigQuery format simultaneously.
+    # -- E.g. If there are 4 cores, and parseBytesFactor = 0.75, then 3 batches gets processed in parallel.
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "transformFactor": 0.75
   }
 
   # Retry configuration for BigQuery operation failures

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -21,7 +21,12 @@
   "batching": {
     "maxBytes": 16000000
     "maxDelay": "1 second"
-    "writeBatchConcurrency":  3
+    "writeBatchConcurrency": 2
+  }
+
+  "cpuParallelism" {
+    "parseBytesFactor": 0.1
+    "transformFactor": 0.75
   }
 
   "retries": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/Processing.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/Processing.scala
@@ -106,9 +106,9 @@ object Processing {
   ): EventProcessor[F] = { in =>
     val badProcessor = BadRowProcessor(env.appInfo.name, env.appInfo.version)
 
-    in.through(parseBytes(badProcessor))
+    in.through(parseBytes(badProcessor, env.cpuParallelism.parseBytes))
       .through(BatchUp.withTimeout(env.batching.maxBytes, env.batching.maxDelay))
-      .through(transform(env, badProcessor))
+      .through(transform(env, badProcessor, env.cpuParallelism.transform))
       .through(handleSchemaEvolution(env))
       .through(writeToBigQuery(env, badProcessor))
       .through(setE2ELatencyMetric(env))
@@ -131,8 +131,8 @@ object Processing {
     }
 
   /** Parse raw bytes into Event using analytics sdk */
-  private def parseBytes[F[_]: Sync](badProcessor: BadRowProcessor): Pipe[F, TokenedEvents, ParseResult] =
-    _.evalMap { case TokenedEvents(chunk, token) =>
+  private def parseBytes[F[_]: Async](badProcessor: BadRowProcessor, parallelism: Int): Pipe[F, TokenedEvents, ParseResult] =
+    _.parEvalMap(parallelism) { case TokenedEvents(chunk, token) =>
       for {
         numBytes <- Sync[F].delay(Foldable[Chunk].sumBytes(chunk))
         (badRows, events) <- Foldable[Chunk].traverseSeparateUnordered(chunk) { byteBuffer =>
@@ -150,9 +150,10 @@ object Processing {
   /** Transform the Event into values compatible with the BigQuery sdk */
   private def transform[F[_]: Async: RegistryLookup](
     env: Environment[F],
-    badProcessor: BadRowProcessor
+    badProcessor: BadRowProcessor,
+    parallelism: Int
   ): Pipe[F, Batched, BatchAfterTransform] =
-    _.evalMap { case Batched(events, parseFailures, countBytes, entities, tokens, earliestCollectorTstamp) =>
+    _.parEvalMap(parallelism) { case Batched(events, parseFailures, countBytes, entities, tokens, earliestCollectorTstamp) =>
       for {
         now <- Sync[F].realTimeInstant
         loadTstamp = BigQueryCaster.timestampValue(now)

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.bigquery/MockEnvironment.scala
@@ -91,6 +91,10 @@ object MockEnvironment {
           maxDelay              = 10.seconds,
           writeBatchConcurrency = 1
         ),
+        cpuParallelism = CpuParallelism(
+          parseBytes = 1,
+          transform  = 1
+        ),
         badRowMaxSize           = 1000000,
         schemasToSkip           = List.empty,
         legacyColumns           = legacyColumns,

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KafkaConfigSpec.scala
@@ -95,7 +95,11 @@ object KafkaConfigSpec {
     batching = Config.Batching(
       maxBytes              = 16000000,
       maxDelay              = 1.second,
-      writeBatchConcurrency = 3
+      writeBatchConcurrency = 2
+    ),
+    cpuParallelism = Config.CpuParallelism(
+      parseBytesFactor = 0.1,
+      transformFactor  = 0.75
     ),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
@@ -168,7 +172,11 @@ object KafkaConfigSpec {
     batching = Config.Batching(
       maxBytes              = 16000000,
       maxDelay              = 1.second,
-      writeBatchConcurrency = 1
+      writeBatchConcurrency = 2
+    ),
+    cpuParallelism = Config.CpuParallelism(
+      parseBytesFactor = 0.1,
+      transformFactor  = 0.75
     ),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/bigquery/KinesisConfigSpec.scala
@@ -95,7 +95,11 @@ object KinesisConfigSpec {
     batching = Config.Batching(
       maxBytes              = 16000000,
       maxDelay              = 1.second,
-      writeBatchConcurrency = 3
+      writeBatchConcurrency = 2
+    ),
+    cpuParallelism = Config.CpuParallelism(
+      parseBytesFactor = 0.1,
+      transformFactor  = 0.75
     ),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
@@ -166,7 +170,11 @@ object KinesisConfigSpec {
     batching = Config.Batching(
       maxBytes              = 16000000,
       maxDelay              = 1.second,
-      writeBatchConcurrency = 1
+      writeBatchConcurrency = 2
+    ),
+    cpuParallelism = Config.CpuParallelism(
+      parseBytesFactor = 0.1,
+      transformFactor  = 0.75
     ),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/bigquery/PubsubConfigSpec.scala
@@ -89,7 +89,11 @@ object PubsubConfigSpec {
     batching = Config.Batching(
       maxBytes              = 16000000,
       maxDelay              = 1.second,
-      writeBatchConcurrency = 3
+      writeBatchConcurrency = 2
+    ),
+    cpuParallelism = Config.CpuParallelism(
+      parseBytesFactor = 0.1,
+      transformFactor  = 0.75
     ),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
@@ -154,7 +158,11 @@ object PubsubConfigSpec {
     batching = Config.Batching(
       maxBytes              = 16000000,
       maxDelay              = 1.second,
-      writeBatchConcurrency = 1
+      writeBatchConcurrency = 2
+    ),
+    cpuParallelism = Config.CpuParallelism(
+      parseBytesFactor = 0.1,
+      transformFactor  = 0.75
     ),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),


### PR DESCRIPTION
For pods with more than 1 CPU, tests have shown that we get a better throughput when adding some parallelism on CPU-intensive steps.

Actually, tests have shown that we get the best throughput when adding parallelism to `transform` step only.

I wonder if we should remove the parallelism on `parseBytes`, but given that it is there now, I'd be in favor of keeping it with a low default, so that there is no parallelism, and if 1 day we want to change it we can.

Also, we've observed better throughput with `writeBatchConcurrency = 2`, so I updated the default.