### PR TITLE
Never use `REQUIRED` mode for new nested fields of existing columns

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQuerySchemaUtils.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.bigquery/processing/BigQuerySchemaUtils.scala
@@ -81,7 +81,7 @@ object BigQuerySchemaUtils {
     val newColumns = ddlFields
       .filterNot(ddlField => bqFieldNames.contains(ddlField.name))
       .map { ddlField =>
-        bqFieldOf(ddlField)
+        bqFieldOf(ddlField.copy(nullability = Type.Nullability.Nullable))
       }
     FieldList.of((alteredExisting ++ newColumns).asJava)
   }


### PR DESCRIPTION
There are edge case tables/schemas in which the loader previously tried to alter the table to add a required nested column to a pre-existing struct column.  We saw this error message:

```
message": "Provided Schema does not match Table <redacted>:<redacted>.events. Cannot add required fields to an existing schema. (field: <redacted>.<redacted>)
```

This scenario happens only if a schema has been patched after the loader already created the column; or if the table is manually altered; or other similar mis-uses of schemas.

This commit works around the issue by forcing nested columns to be NULLABLE if the parent struct column already exists.